### PR TITLE
JP SE-293 Transitive Dependency issues with Ensime/Scalariform

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ If you'd like to run the server, you will need to set up PostgreSQL locally.
 Once this is done, you can navigate to the `site` directory and launch
 SBT. From there, `run` should launch the Play app.
 
+### Troubleshooting
+
+If you use *ensime* and you have configured the `sbt-ensime` plugin in your sbt user
+global settings, likely you might have this issue running the application locally:
+
+```java.lang.NoClassDefFoundError: scalariform/formatter/preferences/SpacesAroundMultiImports$```
+
+In that case, you could solve this issue setting up your `/.sbt/0.13/plugins/plugins.sbt` file
+as follow:
+
+```
+addSbtPlugin("org.ensime" % "ensime-sbt" % "0.4.0")
+
+dependencyOverrides in ThisBuild += "org.scalariform" %% "scalariform" % "0.1.8"
+```
+
 ## Contributing
 
 Contributions welcome! At this time, we don't have an official contribution

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -33,6 +33,7 @@ lazy val compiler = (project in file("compiler"))
     testlibs(
       Dep.cats.laws)
   ))
+  .settings(excludeDependencies += "org.scalariform" % "scalariform_2.10")
   .dependsOn(definitions)
   .dependsOn(runtime % "test")
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -26,7 +26,7 @@ lazy val compiler = (project in file("compiler"))
   .settings(commonSettings: _*)
   .settings(libraryDependencies ++= Seq(
     "org.scalariform" %% "scalariform" % "0.1.8"
-  )).settings(libraryDependencies  <++= (scalaVersion)(scalaVersion =>
+  )).settings(libraryDependencies  <++= scalaVersion(scalaVersion =>
     compilelibs(
       Dep.scala.compiler(scalaVersion),
       Dep.cats.core) ++
@@ -43,7 +43,7 @@ lazy val runtime = (project in file("runtime"))
     name            := "runtime"
   )
   .settings(commonSettings: _*)
-  .settings(libraryDependencies <++= (scalaVersion)(scalaVersion =>
+  .settings(libraryDependencies <++= scalaVersion(scalaVersion =>
     compilelibs(
       Dep.scala.compiler(scalaVersion),
       Dep.cats.core


### PR DESCRIPTION
This PR fixes, on one hand, the conflicting cross-version suffixes in org.scalariform (2.10, 2.11). On the other hand, try to clarify what could the user do in case of runtime exceptions.

Fixes: https://github.com/scala-exercises/scala-exercises/issues/293

Please, @raulraja @dialelo Could you review? Thanks.