### PR TITLE
Make Compile configuration behave

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -92,7 +92,9 @@ lazy val `sbt-exercise` = (project in file("sbt-exercise"))
     scripted <<= scripted dependsOn (scalariformFormat in scriptedConf),
     inConfig(scriptedConf) {
       sourceDirectories in scalariformFormat <<= sbtTestDirectory { dir =>
-        val bases = dir * "*" * "*" / "src" / "main"
+        // the scalariform tests require poorly formatted code, so
+        // ignore that dir
+        val bases = dir * "*" * ("*" -- "scalariform") / "src" / "main"
         (bases / "scala").get ++ (bases / "exercises").get
       }
     }

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/test
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/test
@@ -1,8 +1,7 @@
 -$ exists target/scala-2.11/src_managed/main/defaultLib/
 -$ exists target/scala-2.11/resource_managed/main/scala-exercises/library.47
 
-> compile
-> copyResources
+> package
 
 $ exists target/scala-2.11/src_managed/main/defaultLib/
 $ exists target/scala-2.11/resource_managed/main/scala-exercises/library.47

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/build.sbt
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/build.sbt
@@ -1,0 +1,3 @@
+lazy val root = (project in file("."))
+  .enablePlugins(ExerciseCompilerPlugin)
+  .settings(scalaVersion := "2.11.7")

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/project/plugins.sbt
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/project/plugins.sbt
@@ -1,0 +1,10 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.47deg" % "sbt-exercise" % pluginVersion)
+}
+
+resolvers += Resolver.typesafeRepo("releases")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/src/main/scala/sample.scala
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/src/main/scala/sample.scala
@@ -1,0 +1,17 @@
+//
+
+
+object PoorlyFormatted extends App {
+  println("it's " + { 1  + {
+  // this file
+    // is poorly
+      // formatted
+
+      Option(1)
+    .map(_ + 1)
+  .map(_ * 10)
+    .map(_ /
+11) getOrElse   100
+}
+
+}        )        }

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/test
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/test
@@ -1,3 +1,3 @@
 $ copy src/main/scala/sample.scala sample.scala.original
 > package
--$ newer src/main/scala/sample.scala sample.scala.original
+$ newer src/main/scala/sample.scala sample.scala.original

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/test
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/scalariform/test
@@ -1,0 +1,3 @@
+$ copy src/main/scala/sample.scala sample.scala.original
+> package
+-$ newer src/main/scala/sample.scala sample.scala.original

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -122,13 +122,13 @@ import de.heikoseeberger.sbtheader.HeaderPlugin
 lazy val content = (project in file("content"))
   .enablePlugins(ExerciseCompilerPlugin)
   .dependsOn(ProjectRef(file("../core"), "runtime"))
-  .dependsOn(ProjectRef(file("../core"), "definitions") % CompileMain)
+  .dependsOn(ProjectRef(file("../core"), "runtime") % CompileGeneratedExercises)
   .dependsOn(ProjectRef(file("../core"), "definitions"))
   .settings(commonSettings: _*)
   .settings(libraryDependencies ++=
-    Seq(
-      "org.scalatest" %% "scalatest" % "2.2.4" % CompileMain,
-      "com.chuusai" %% "shapeless" % "2.2.5" % CompileMain
+    compilelibs(
+      "org.scalatest" %% "scalatest" % "2.2.4",
+      "com.chuusai" %% "shapeless" % "2.2.5"
     ) ++
     testlibs(
       "org.scalatest" %% "scalatest" % "2.2.4",
@@ -137,7 +137,4 @@ lazy val content = (project in file("content"))
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1"
     ) :+
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
-  )
-  .settings(
-    HeaderPlugin.settingsFor(CompileMain)
   )

--- a/site/content/src/main/scala/catslib/Applicative.scala
+++ b/site/content/src/main/scala/catslib/Applicative.scala
@@ -6,7 +6,6 @@ import cats._
 import cats.std.all._
 
 /**
-  *
   * `Applicative` extends `Apply` by adding a single method, `pure`:
   *
   * {{{
@@ -18,8 +17,7 @@ import cats.std.all._
   */
 object ApplicativeSection extends FlatSpec with Matchers with exercise.Section {
 
-  /**
-    * This method takes any value and returns the value in the context of
+  /** This method takes any value and returns the value in the context of
     * the functor. For many familiar functors, how to do this is
     * obvious. For `Option`, the `pure` operation wraps the value in
     * `Some`. For `List`, the `pure` operation returns a single element
@@ -34,8 +32,7 @@ object ApplicativeSection extends FlatSpec with Matchers with exercise.Section {
     Applicative[List].pure(1) should be(res1)
   }
 
-  /**
-    * Like `Functor` and `Apply`, `Applicative`
+  /** Like `Functor` and `Apply`, `Applicative`
     * functors also compose naturally with each other. When
     * you compose one `Applicative` with another, the resulting `pure`
     * operation will lift the passed value into one context, and the result
@@ -45,8 +42,7 @@ object ApplicativeSection extends FlatSpec with Matchers with exercise.Section {
     (Applicative[List] compose Applicative[Option]).pure(1) should be(res0)
   }
 
-  /**
-    * = Applicative Functors & Monads =
+  /** = Applicative Functors & Monads =
     *
     * `Applicative` is a generalization of `Monad`, allowing expression
     * of effectful computations in a pure functional way.

--- a/site/content/src/main/scala/catslib/Apply.scala
+++ b/site/content/src/main/scala/catslib/Apply.scala
@@ -8,8 +8,7 @@ import cats.std.all._
 import cats.syntax.apply._
 import cats.syntax.cartesian._
 
-/**
-  * `Apply` extends the `Functor` type class (which features the familiar `map`
+/** `Apply` extends the `Functor` type class (which features the familiar `map`
   * function) with a new function `ap`. The `ap` function is similar to `map`
   * in that we are transforming a value in a context (a context being the `F` in `F[A]`;
   * a context can be `Option`, `List` or `Future` for example).
@@ -21,59 +20,56 @@ import cats.syntax.cartesian._
   * import cats._
   *
   * implicit val optionApply: Apply[Option] = new Apply[Option] {
-  *   def ap[A, B](f: Option[A => B])(fa: Option[A]): Option[B] =
-  *     fa.flatMap (a => f.map (ff => ff(a)))
+  *  def ap[A, B](f: Option[A => B])(fa: Option[A]): Option[B] =
+  *    fa.flatMap (a => f.map (ff => ff(a)))
   *
-  *   def map[A,B](fa: Option[A])(f: A => B): Option[B] = fa map f
+  *  def map[A,B](fa: Option[A])(f: A => B): Option[B] = fa map f
   *
-  *   def product[A, B](fa: Option[A], fb: Option[B]): Option[(A, B)] =
-  *     fa.flatMap(a => fb.map(b => (a, b)))
+  *  def product[A, B](fa: Option[A], fb: Option[B]): Option[(A, B)] =
+  *    fa.flatMap(a => fb.map(b => (a, b)))
   * }
   *
   * implicit val listApply: Apply[List] = new Apply[List] {
-  *   def ap[A, B](f: List[A => B])(fa: List[A]): List[B] =
-  *     fa.flatMap (a => f.map (ff => ff(a)))
+  *  def ap[A, B](f: List[A => B])(fa: List[A]): List[B] =
+  *    fa.flatMap (a => f.map (ff => ff(a)))
   *
-  *   def map[A,B](fa: List[A])(f: A => B): List[B] = fa map f
+  *  def map[A,B](fa: List[A])(f: A => B): List[B] = fa map f
   *
-  *   def product[A, B](fa: List[A], fb: List[B]): List[(A, B)] =
-  *     fa.zip(fb)
+  *  def product[A, B](fa: List[A], fb: List[B]): List[(A, B)] =
+  *    fa.zip(fb)
   * }
   * }}}
   *
   * @param name apply
   */
 object ApplySection extends FlatSpec with Matchers with exercise.Section {
-  /**
-    * = map =
+  /** = map =
     *
     * Since `Apply` extends `Functor`, we can use the `map` method from `Functor`:
     */
   def applyExtendsFunctor(res0: Option[String], res1: Option[Int], res2: Option[Int]) = {
     import cats.std.all._
 
-    val intToString: Int => String = _.toString
-    val double: Int => Int = _ * 2
-    val addTwo: Int => Int = _ + 2
+    val intToString: Int ⇒ String = _.toString
+    val double: Int ⇒ Int = _ * 2
+    val addTwo: Int ⇒ Int = _ + 2
 
     Apply[Option].map(Some(1))(intToString) should be(res0)
     Apply[Option].map(Some(1))(double) should be(res1)
     Apply[Option].map(None)(double) should be(res2)
   }
 
-  /**
-    * = compose =
+  /** = compose =
     *
     * And like functors, `Apply` instances also compose:
     */
   def applyComposes(res0: List[Option[Int]]) = {
     val listOpt = Apply[List] compose Apply[Option]
-    val plusOne = (x:Int) => x + 1
+    val plusOne = (x: Int) ⇒ x + 1
     listOpt.ap(List(Some(plusOne)))(List(Some(1), None, Some(3))) should be(res0)
   }
 
-  /**
-    * = ap =
+  /** = ap =
     *
     * The `ap` method is a method that `Functor` does not have:
     */
@@ -85,27 +81,25 @@ object ApplySection extends FlatSpec with Matchers with exercise.Section {
     Apply[Option].ap(None)(None) should be(res4)
   }
 
-  /**
-    * = ap2, ap3, etc =
+  /** = ap2, ap3, etc =
     *
     * `Apply` also offers variants of `ap`. The functions `apN` (for `N` between `2` and `22`)
-    *  accept `N` arguments where `ap` accepts `1`.
+    * accept `N` arguments where `ap` accepts `1`.
     *
     * Note that if any of the arguments of this example is `None`, the
     * final result is `None` as well.  The effects of the context we are operating on
     * are carried through the entire computation:
     */
   def applyApn(res0: Option[Int], res1: Option[Int], res2: Option[Int]) = {
-    val addArity2 = (a: Int, b: Int) => a + b
+    val addArity2 = (a: Int, b: Int) ⇒ a + b
     Apply[Option].ap2(Some(addArity2))(Some(1), Some(2)) should be(res0)
     Apply[Option].ap2(Some(addArity2))(Some(1), None) should be(res1)
 
-    val addArity3 = (a: Int, b: Int, c: Int) => a + b + c
+    val addArity3 = (a: Int, b: Int, c: Int) ⇒ a + b + c
     Apply[Option].ap3(Some(addArity3))(Some(1), Some(2), Some(3)) should be(res2)
   }
 
-  /**
-    * = map2, map3, etc =
+  /** = map2, map3, etc =
     *
     * Similarly, `mapN` functions are available:
     *
@@ -116,8 +110,7 @@ object ApplySection extends FlatSpec with Matchers with exercise.Section {
     Apply[Option].map3(Some(1), Some(2), Some(3))(addArity3) should be(res1)
   }
 
-  /**
-    * = tuple2, tuple3, etc =
+  /** = tuple2, tuple3, etc =
     *
     * Similarly, `tupleN` functions are available:
     *
@@ -127,8 +120,7 @@ object ApplySection extends FlatSpec with Matchers with exercise.Section {
     Apply[Option].tuple3(Some(1), Some(2), Some(3)) should be(res1)
   }
 
-  /**
-    * = apply builder syntax =
+  /** = apply builder syntax =
     *
     * The `|@|` operator offers an alternative syntax for the higher-arity `Apply`
     * functions (`apN`, `mapN` and `tupleN`).

--- a/site/content/src/main/scala/catslib/ApplyHelpers.scala
+++ b/site/content/src/main/scala/catslib/ApplyHelpers.scala
@@ -1,9 +1,9 @@
 package catslib
 
 object ApplyHelpers {
-  val intToString: Int => String = _.toString
-  val double: Int => Int = _ * 2
-  val addTwo: Int => Int = _ + 2
-  val addArity2 = (a: Int, b: Int) => a + b
-  val addArity3 = (a: Int, b: Int, c: Int) => a + b + c
+  val intToString: Int ⇒ String = _.toString
+  val double: Int ⇒ Int = _ * 2
+  val addTwo: Int ⇒ Int = _ + 2
+  val addArity2 = (a: Int, b: Int) ⇒ a + b
+  val addArity3 = (a: Int, b: Int, c: Int) ⇒ a + b + c
 }

--- a/site/content/src/main/scala/catslib/CatsLibrary.scala
+++ b/site/content/src/main/scala/catslib/CatsLibrary.scala
@@ -1,7 +1,6 @@
 package catslib
 
-/**
-  * Cats is an experimental library intended to provide abstractions for functional programming in Scala.
+/** Cats is an experimental library intended to provide abstractions for functional programming in Scala.
   *
   * @param name cats
   */

--- a/site/content/src/main/scala/catslib/Foldable.scala
+++ b/site/content/src/main/scala/catslib/Foldable.scala
@@ -5,8 +5,7 @@ import org.scalatest._
 import cats._
 import cats.implicits._
 
-/**
-  * Foldable type class instances can be defined for data structures that can be
+/** Foldable type class instances can be defined for data structures that can be
   * folded to a summary value.
   *
   * In the case of a collection (such as `List` or `Set`), these methods will fold
@@ -16,8 +15,8 @@ import cats.implicits._
   *
   * `Foldable[F]` is implemented in terms of two basic methods:
   *
-  *  - `foldLeft(fa, b)(f)` eagerly folds `fa` from left-to-right.
-  *  - `foldRight(fa, b)(f)` lazily folds `fa` from right-to-left.
+  * - `foldLeft(fa, b)(f)` eagerly folds `fa` from left-to-right.
+  * - `foldRight(fa, b)(f)` lazily folds `fa` from right-to-left.
   *
   *
   * These form the basis for many other operations, see also:
@@ -35,8 +34,7 @@ import cats.implicits._
   * @param name foldable
   */
 object FoldableSection extends FlatSpec with Matchers with exercise.Section {
-  /**
-    * = foldLeft =
+  /** = foldLeft =
     *
     * `foldLeft` is an eager left-associative fold on `F` using the given function.
     *
@@ -46,8 +44,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].foldLeft(List("a", "b", "c"), "")(_ + _) should be(res1)
   }
 
-  /**
-    * = foldRight =
+  /** = foldRight =
     *
     * `foldRight` is a lazy right-associative fold on `F` using the given function.
     * The function has the signature `(A, Eval[B]) => Eval[B]` to support laziness in
@@ -55,12 +52,11 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     *
     */
   def foldableFoldRight(res0: Int) = {
-    val lazyResult = Foldable[List].foldRight(List(1, 2, 3), Now(0))((x, rest) => Later(x + rest.value))
+    val lazyResult = Foldable[List].foldRight(List(1, 2, 3), Now(0))((x, rest) ⇒ Later(x + rest.value))
     lazyResult.value should be(res0)
   }
 
-  /**
-    * = fold =
+  /** = fold =
     *
     * `fold`, also called `combineAll`, combines every value in the foldable using the fiven `Monoid` instance.
     *
@@ -70,8 +66,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].fold(List(1, 2, 3)) should be(res1) // Hint: the implicit monoid for `Int` is the Sum monoid
   }
 
-  /**
-    * = foldMap =
+  /** = foldMap =
     *
     * `foldMap` is similar to `fold` but maps every `A` value into `B` and then
     * combines them using the given `Monoid[B]` instance.
@@ -82,8 +77,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].foldMap(List(1, 2, 3))(_.toString) should be(res1)
   }
 
-  /**
-    * = foldK =
+  /** = foldK =
     *
     * `foldK` is similar to `fold` but combines every value in the foldable using the fiven `MonoidK[G]` instance
     * instead of `Monoid[G]`.
@@ -93,8 +87,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].foldK(List(None, Option("two"), Option("three"))) should be(res1)
   }
 
-  /**
-    * = find =
+  /** = find =
     *
     * `find` searches for the first element matching the predicate, if one exists.
     */
@@ -103,8 +96,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].find(List(1, 2, 3))(_ > 5) should be(res1)
   }
 
-  /**
-    * = exists =
+  /** = exists =
     *
     * `exists` checks whether at least one element satisfies the predicate.
     */
@@ -113,8 +105,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].exists(List(1, 2, 3))(_ > 5) should be(res1)
   }
 
-  /**
-    * = forall =
+  /** = forall =
     *
     * `forall` checks whether all elements satisfy the predicate.
     */
@@ -123,8 +114,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].forall(List(1, 2, 3))(_ < 3) should be(res1)
   }
 
-  /**
-    * = toList =
+  /** = toList =
     *
     * Convert `F[A]` to `List[A]`.
     */
@@ -134,8 +124,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[Option].toList(None) should be(res2)
   }
 
-  /**
-    * = filter_ =
+  /** = filter_ =
     *
     * Convert `F[A]` to `List[A]` only including the elements that match a predicate.
     */
@@ -144,8 +133,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[Option].filter_(Option(42))(_ != 42) should be(res1)
   }
 
-  /**
-    * = traverse_ =
+  /** = traverse_ =
     *
     * `traverse` the foldable mapping `A` values to `G[B]`, and combining
     * them using `Applicative[G]` and discarding the results.
@@ -166,8 +154,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].traverse_(List("a", "b", "c"))(parseInt) should be(res1)
   }
 
-  /**
-    * = compose =
+  /** = compose =
     *
     * We can compose `Foldable[F[_]]` and `Foldable[G[_]]` instances to obtain `Foldable[F[G]]`.
     */
@@ -177,8 +164,7 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     FoldableListOption.fold(List(Option("1"), Option("2"), None, Option("3"))) should be(res1)
   }
 
-  /**
-    * = More Foldable methods =
+  /** = More Foldable methods =
     *
     * Hence when defining some new data structure, if we can define a `foldLeft` and
     * `foldRight` we are able to provide many other useful operations, if not always
@@ -194,6 +180,5 @@ object FoldableSection extends FlatSpec with Matchers with exercise.Section {
     Foldable[List].dropWhile_(List(1, 2, 3))(_ < 2) should be(res1)
     Foldable[List].takeWhile_(List(1, 2, 3))(_ < 2) should be(res2)
   }
-
 
 }

--- a/site/content/src/main/scala/catslib/FunctorSection.scala
+++ b/site/content/src/main/scala/catslib/FunctorSection.scala
@@ -37,11 +37,11 @@ import cats.std.list._
   * import cats._
   *
   * implicit val optionFunctor: Functor[Option] = new Functor[Option] {
-  *   def map[A,B](fa: Option[A])(f: A => B) = fa map f
+  *  def map[A,B](fa: Option[A])(f: A => B) = fa map f
   * }
   *
   * implicit val listFunctor: Functor[List] = new Functor[List] {
-  *   def map[A,B](fa: List[A])(f: A => B) = fa map f
+  *  def map[A,B](fa: List[A])(f: A => B) = fa map f
   * }
   * }}}
   *
@@ -51,9 +51,9 @@ import cats.std.list._
   *
   * {{{
   * implicit def function1Functor[In]: Functor[Function1[In, ?]] =
-  *   new Functor[Function1[In, ?]] {
-  *     def map[A,B](fa: In => A)(f: A => B): Function1[In,B] = fa andThen f
-  *   }
+  *  new Functor[Function1[In, ?]] {
+  *    def map[A,B](fa: In => A)(f: A => B): Function1[In,B] = fa andThen f
+  *  }
   * }}}
   *
   * This example demonstrates the use of the
@@ -69,7 +69,6 @@ import cats.std.list._
   */
 object FunctorSection extends FlatSpec with Matchers with exercise.Section {
   /**
-    *
     * = Using Functor =
     *
     * == map ==
@@ -90,7 +89,6 @@ object FunctorSection extends FlatSpec with Matchers with exercise.Section {
   }
 
   /**
-    *
     * = Derived methods =
     *
     * == lift ==
@@ -102,16 +100,15 @@ object FunctorSection extends FlatSpec with Matchers with exercise.Section {
     * lenOption(Some("abcd"))
     * }}}
     *
-    *  We can now apply the `lenOption` function to `Option` instances.
+    * We can now apply the `lenOption` function to `Option` instances.
     *
     */
   def liftingToAFunctor(res0: Option[Int]) = {
-    val lenOption: Option[String] => Option[Int] = Functor[Option].lift(_.length)
+    val lenOption: Option[String] ⇒ Option[Int] = Functor[Option].lift(_.length)
     lenOption(Some("Hello")) should be(res0)
   }
 
-  /**
-    * == fproduct ==
+  /** == fproduct ==
     *
     * `Functor` provides an `fproduct` function which pairs a value with the
     * result of applying a function to that value.
@@ -127,7 +124,6 @@ object FunctorSection extends FlatSpec with Matchers with exercise.Section {
   }
 
   /**
-    *
     * == compose ==
     *
     * Functors compose! Given any functor `F[_]` and any functor `G[_]` we can

--- a/site/content/src/main/scala/catslib/IdentitySection.scala
+++ b/site/content/src/main/scala/catslib/IdentitySection.scala
@@ -33,7 +33,7 @@ object IdentitySection extends FlatSpec with Matchers with exercise.Section {
     */
   def identityType(res0: Int) {
     val anId: Id[Int] = 42
-    anId should be (res0)
+    anId should be(res0)
   }
 
   /** Using this type declaration, we can treat our Id type constructor as a
@@ -51,15 +51,15 @@ object IdentitySection extends FlatSpec with Matchers with exercise.Section {
     *
     */
   def pureIdentity(res0: Int) = {
-    Applicative[Id].pure(42) should be (res0)
+    Applicative[Id].pure(42) should be(res0)
   }
 
   /** Compare the signatures of `map` and `flatMap` and `coflatMap`:
     *
     * {{{
-    *   def map[A, B](fa: Id[A])(f: A => B): Id[B]
-    *   def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B]
-    *   def coflatMap[A, B](a: Id[A])(f: Id[A] => B): Id[B]
+    *  def map[A, B](fa: Id[A])(f: A => B): Id[B]
+    *  def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B]
+    *  def coflatMap[A, B](a: Id[A])(f: Id[A] => B): Id[B]
     * }}}
     *
     * You'll notice that in the flatMap signature, since `Id[B]` is the same
@@ -80,6 +80,6 @@ object IdentitySection extends FlatSpec with Matchers with exercise.Section {
     */
   def idComonad(res0: Int) = {
     val fortytwo: Int = 42
-    Comonad[Id].coflatMap(fortytwo)(_ + 1) should be (res0)
+    Comonad[Id].coflatMap(fortytwo)(_ + 1) should be(res0)
   }
 }

--- a/site/content/src/main/scala/catslib/Monad.scala
+++ b/site/content/src/main/scala/catslib/Monad.scala
@@ -5,8 +5,7 @@ import org.scalatest._
 import cats._
 import MonadHelpers._
 
-/**
-  * `Monad` extends the `Applicative` type class with a
+/** `Monad` extends the `Applicative` type class with a
   * new function `flatten`. Flatten takes a value in a nested context (eg.
   * `F[F[A]]` where F is the context) and "joins" the contexts together so
   * that we have a single context (ie. `F[A]`).
@@ -14,18 +13,16 @@ import MonadHelpers._
   * @param name monad
   */
 object MonadSection extends FlatSpec with Matchers with exercise.Section {
-  /**
-    * The name `flatten` should remind you of the functions of the same name on many
+  /** The name `flatten` should remind you of the functions of the same name on many
     * classes in the standard library.
     */
   def flattenRecap(res0: Option[Int], res1: Option[Int], res2: List[Int]) = {
     Option(Option(1)).flatten should be(res0)
     Option(None).flatten should be(res1)
-    List(List(1),List(2,3)).flatten should be(res2)
+    List(List(1), List(2, 3)).flatten should be(res2)
   }
 
-  /**
-    * = Monad instances =
+  /** = Monad instances =
     *
     * If `Applicative` is already present and `flatten` is well-behaved,
     * extending the `Applicative` to a `Monad` is trivial. To provide evidence
@@ -41,13 +38,13 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     * import cats._
     *
     * implicit def optionMonad(implicit app: Applicative[Option]) =
-    *   new Monad[Option] {
-    *     // Define flatMap using Option's flatten method
-    *     override def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
-    *       app.map(fa)(f).flatten
-    *     // Reuse this definition from Applicative.
-    *     override def pure[A](a: A): Option[A] = app.pure(a)
-    *   }
+    *  new Monad[Option] {
+    *    // Define flatMap using Option's flatten method
+    *    override def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
+    *      app.map(fa)(f).flatten
+    *    // Reuse this definition from Applicative.
+    *    override def pure[A](a: A): Option[A] = app.pure(a)
+    *  }
     * }}}
     *
     * Cats already provides a `Monad` instance of `Option`.
@@ -60,8 +57,7 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     Monad[Option].pure(42) should be(res0)
   }
 
-  /**
-    * = flatMap =
+  /** = flatMap =
     *
     * `flatMap` is often considered to be the core function of `Monad`, and cats
     * follows this tradition by providing implementations of `flatten` and `map`
@@ -69,8 +65,8 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * implicit val listMonad = new Monad[List] {
-    *   def flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
-    *   def pure[A](a: A): List[A] = List(a)
+    *  def flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
+    *  def pure[A](a: A): List[A] = List(a)
     * }
     * }}}
     *
@@ -82,11 +78,10 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     import cats._
     import cats.std.list._
 
-    Monad[List].flatMap(List(1, 2, 3))(x => List(x, x)) should be(res0)
+    Monad[List].flatMap(List(1, 2, 3))(x ⇒ List(x, x)) should be(res0)
   }
 
-  /**
-    * = ifM =
+  /** = ifM =
     *
     * `Monad` provides the ability to choose later operations in a sequence based on
     * the results of earlier ones. This is embodied in `ifM`, which lifts an `if`
@@ -100,8 +95,7 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     Monad[List].ifM(List(true, false, true))(List(1, 2), List(3, 4)) should be(res1)
   }
 
-  /**
-    * = Composition =
+  /** = Composition =
     *
     * Unlike `Functor`s and `Applicative`s
     * not all `Monad`s compose. This means that even if `M[_]` and `N[_]` are
@@ -116,16 +110,16 @@ object MonadSection extends FlatSpec with Matchers with exercise.Section {
     * case class OptionT[F[_], A](value: F[Option[A]])
     *
     * implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
-    *   new Monad[OptionT[F, ?]] {
-    *     def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
-    *     def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
-    *       OptionT {
-    *         F.flatMap(fa.value) {
-    *           case None => F.pure(None)
-    *           case Some(a) => f(a).value
-    *         }
-    *       }
-    *   }
+    *  new Monad[OptionT[F, ?]] {
+    *    def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
+    *    def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+    *      OptionT {
+    *        F.flatMap(fa.value) {
+    *          case None => F.pure(None)
+    *          case Some(a) => f(a).value
+    *        }
+    *      }
+    *  }
     * }
     * }}}
     *

--- a/site/content/src/main/scala/catslib/MonadHelpers.scala
+++ b/site/content/src/main/scala/catslib/MonadHelpers.scala
@@ -5,14 +5,14 @@ import cats.Monad
 object MonadHelpers {
   case class OptionT[F[_], A](value: F[Option[A]])
 
-  implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
+  implicit def optionTMonad[F[_]](implicit F: Monad[F]) = {
     new Monad[OptionT[F, ?]] {
       def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
-      def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+      def flatMap[A, B](fa: OptionT[F, A])(f: A ⇒ OptionT[F, B]): OptionT[F, B] =
         OptionT {
           F.flatMap(fa.value) {
-            case None => F.pure(None)
-            case Some(a) => f(a).value
+            case None    ⇒ F.pure(None)
+            case Some(a) ⇒ f(a).value
           }
         }
     }

--- a/site/content/src/main/scala/catslib/Monoid.scala
+++ b/site/content/src/main/scala/catslib/Monoid.scala
@@ -6,8 +6,7 @@ import cats._
 import cats.std.all._
 import cats.syntax.all._
 
-/**
-  * `Monoid` extends the `Semigroup` type class, adding an
+/** `Monoid` extends the `Semigroup` type class, adding an
   * `empty` method to semigroup's `combine`. The `empty` method must return a
   * value that when combined with any other instance of that type returns the
   * other instance, i.e.
@@ -27,8 +26,7 @@ import cats.syntax.all._
   * @param name monoid
   */
 object MonoidSection extends FlatSpec with Matchers with exercise.Section {
-  /**
-    * First some imports.
+  /** First some imports.
     *
     * {{{
     * import cats._
@@ -46,18 +44,16 @@ object MonoidSection extends FlatSpec with Matchers with exercise.Section {
     Monoid[String].combineAll(List()) should be(res2)
   }
 
-  /**
-    * The advantage of using these type class provided methods, rather than the
+  /** The advantage of using these type class provided methods, rather than the
     * specific ones for each type, is that we can compose monoids to allow us to
     * operate on more complex types, e.g.
     */
   def monoidAdvantage(res0: Map[String, Int], res1: Map[String, Int]) = {
-    Monoid[Map[String,Int]].combineAll(List(Map("a" -> 1, "b" -> 2), Map("a" -> 3))) should be(res0)
-    Monoid[Map[String,Int]].combineAll(List()) should be(res1)
+    Monoid[Map[String, Int]].combineAll(List(Map("a" → 1, "b" → 2), Map("a" → 3))) should be(res0)
+    Monoid[Map[String, Int]].combineAll(List()) should be(res1)
   }
 
-  /**
-    * This is also true if we define our own instances. As an example, let's use
+  /** This is also true if we define our own instances. As an example, let's use
     * `Foldable`'s `foldMap`, which maps over values accumulating
     * the results, using the available `Monoid` for the type mapped onto.
     *
@@ -65,19 +61,18 @@ object MonoidSection extends FlatSpec with Matchers with exercise.Section {
   def monoidFoldmap(res0: Int, res1: String) = {
     val l = List(1, 2, 3, 4, 5)
     l.foldMap(identity) should be(res0)
-    l.foldMap(i => i.toString) should be(res1)
+    l.foldMap(i ⇒ i.toString) should be(res1)
   }
 
-  /**
-    * To use this
-    * with a function that produces a tuple, we can define a `Monoid` for a tuple 
-    * that will be valid for any tuple where the types it contains also have a 
+  /** To use this
+    * with a function that produces a tuple, we can define a `Monoid` for a tuple
+    * that will be valid for any tuple where the types it contains also have a
     * `Monoid` available.
     *
     * This way we are able to combine both values in one pass, hurrah!
     */
   def tupleMonoid(res0: (Int, String)) = {
-    implicit def tupleMonoid[A : Monoid, B : Monoid]: Monoid[(A, B)] =
+    implicit def tupleMonoid[A: Monoid, B: Monoid]: Monoid[(A, B)] =
       new Monoid[(A, B)] {
         def combine(x: (A, B), y: (A, B)): (A, B) = {
           val (xa, xb) = x
@@ -88,6 +83,6 @@ object MonoidSection extends FlatSpec with Matchers with exercise.Section {
       }
 
     val l = List(1, 2, 3, 4, 5)
-    l.foldMap(i => (i, i.toString)) should be(res0)
+    l.foldMap(i ⇒ (i, i.toString)) should be(res0)
   }
 }

--- a/site/content/src/main/scala/catslib/Validated.scala
+++ b/site/content/src/main/scala/catslib/Validated.scala
@@ -8,8 +8,7 @@ import cats.data.Xor
 
 import ValidatedHelpers._
 
-/**
-  * Imagine you are filling out a web form to signup for an account. You input your username and password and submit.
+/** Imagine you are filling out a web form to signup for an account. You input your username and password and submit.
   * Response comes back saying your username can't have dashes in it, so you make some changes and resubmit. Can't
   * have special characters either. Change, resubmit. Passwords need to have at least one capital letter. Change,
   * resubmit. Password needs to have at least one number.
@@ -21,8 +20,8 @@ import ValidatedHelpers._
   * case class ConnectionParams(url: String, port: Int)
   *
   * for {
-  *   url  <- config[String]("url")
-  *   port <- config[Int]("port")
+  *  url  <- config[String]("url")
+  *  port <- config[Int]("port")
   * } yield ConnectionParams(url, port)
   * }}}
   *
@@ -48,21 +47,21 @@ import ValidatedHelpers._
   *
   * {{{
   * trait Read[A] {
-  *   def read(s: String): Option[A]
+  *  def read(s: String): Option[A]
   * }
   *
   * object Read {
-  *   def apply[A](implicit A: Read[A]): Read[A] = A
+  *  def apply[A](implicit A: Read[A]): Read[A] = A
   *
-  *   implicit val stringRead: Read[String] =
-  *     new Read[String] { def read(s: String): Option[String] = Some(s) }
+  *  implicit val stringRead: Read[String] =
+  *    new Read[String] { def read(s: String): Option[String] = Some(s) }
   *
-  *   implicit val intRead: Read[Int] =
-  *     new Read[Int] {
-  *       def read(s: String): Option[Int] =
-  *         if (s.matches("-?[0-9]+")) Some(s.toInt)
-  *         else None
-  *     }
+  *  implicit val intRead: Read[Int] =
+  *    new Read[Int] {
+  *      def read(s: String): Option[Int] =
+  *        if (s.matches("-?[0-9]+")) Some(s.toInt)
+  *        else None
+  *    }
   * }
   * }}}
   *
@@ -83,8 +82,8 @@ import ValidatedHelpers._
   * sealed abstract class Validated[+E, +A]
   *
   * object Validated {
-  *   final case class Valid[+A](a: A) extends Validated[Nothing, A]
-  *   final case class Invalid[+E](e: E) extends Validated[E, Nothing]
+  *  final case class Valid[+A](a: A) extends Validated[Nothing, A]
+  *  final case class Invalid[+E](e: E) extends Validated[E, Nothing]
   * }
   * }}}
   *
@@ -95,30 +94,30 @@ import ValidatedHelpers._
   * import cats.data.Validated.{Invalid, Valid}
   *
   * case class Config(map: Map[String, String]) {
-  *   def parse[A : Read](key: String): Validated[ConfigError, A] =
-  *     map.get(key) match {
-  *       case None        => Invalid(MissingConfig(key))
-  *       case Some(value) =>
-  *         Read[A].read(value) match {
-  *           case None    => Invalid(ParseError(key))
-  *           case Some(a) => Valid(a)
-  *         }
-  *     }
+  *  def parse[A : Read](key: String): Validated[ConfigError, A] =
+  *    map.get(key) match {
+  *      case None        => Invalid(MissingConfig(key))
+  *      case Some(value) =>
+  *        Read[A].read(value) match {
+  *          case None    => Invalid(ParseError(key))
+  *          case Some(a) => Valid(a)
+  *        }
+  *    }
   * }
   * }}}
-
+  *
   * Everything is in place to write the parallel validator. Recall that we can only do parallel
   * validation if each piece is independent. How do we enforce the data is independent? By asking
   * for all of it up front. Let's start with two pieces of data.
   *
   * {{{
   * def parallelValidate[E, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
-  *   (v1, v2) match {
-  *     case (Valid(a), Valid(b))       => Valid(f(a, b))
-  *     case (Valid(_), i@Invalid(_))   => i
-  *     case (i@Invalid(_), Valid(_))   => i
-  *     case (Invalid(e1), Invalid(e2)) => ???
-  *   }
+  *  (v1, v2) match {
+  *    case (Valid(a), Valid(b))       => Valid(f(a, b))
+  *    case (Valid(_), i@Invalid(_))   => i
+  *    case (i@Invalid(_), Valid(_))   => i
+  *    case (Invalid(e1), Invalid(e2)) => ???
+  *  }
   * }}}
   *
   * We've run into a problem. In the case where both have errors, we want to report both. But we have
@@ -131,12 +130,12 @@ import ValidatedHelpers._
   * import cats.Semigroup
   *
   * def parallelValidate[E : Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
-  *   (v1, v2) match {
-  *     case (Valid(a), Valid(b))       => Valid(f(a, b))
-  *     case (Valid(_), i@Invalid(_))   => i
-  *     case (i@Invalid(_), Valid(_))   => i
-  *     case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
-  *   }
+  *  (v1, v2) match {
+  *    case (Valid(a), Valid(b))       => Valid(f(a, b))
+  *    case (Valid(_), i@Invalid(_))   => i
+  *    case (i@Invalid(_), Valid(_))   => i
+  *    case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
+  *  }
   * }}}
   *
   * Perfect! But.. going back to our example, we don't have a way to combine `ConfigError`s. But as clients,
@@ -155,7 +154,7 @@ import ValidatedHelpers._
   * import cats.std.list._
   *
   * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
-  *   SemigroupK[NonEmptyList].algebra[ConfigError]
+  *  SemigroupK[NonEmptyList].algebra[ConfigError]
   *
   * implicit val readString: Read[String] = Read.stringRead
   * implicit val readInt: Read[Int] = Read.intRead
@@ -164,8 +163,7 @@ import ValidatedHelpers._
   * @param name validated
   */
 object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
-  /**
-    * When no errors are present in the configuration, we get a `ConnectionParams` wrapped in a `Valid` instance.
+  /** When no errors are present in the configuration, we get a `ConnectionParams` wrapped in a `Valid` instance.
     */
   def noErrors(res0: Boolean, res1: String, res2: Int) = {
     val config = Config(Map(("url", "127.0.0.1"), ("port", "1337")))
@@ -179,8 +177,7 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     valid.getOrElse(ConnectionParams("", 0)) should be(ConnectionParams(res1, res2))
   }
 
-  /**
-    * But what happens when having one or more errors? They are accumulated in a `NonEmptyList`
+  /** But what happens when having one or more errors? They are accumulated in a `NonEmptyList`
     * wrapped in a `Invalid` instance.
     */
   def someErrors(res0: Boolean, res1: Boolean) = {
@@ -200,7 +197,6 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
   }
 
   /**
-    *
     * = Apply =
     *
     * Our `parallelValidate` function looks awfully like the `Apply#map2` function.
@@ -217,20 +213,20 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     * import cats.Applicative
     *
     * implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, ?]] =
-    *   new Applicative[Validated[E, ?]] {
-    *     def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
-    *       (fa, f) match {
-    *         case (Valid(a), Valid(fab)) => Valid(fab(a))
-    *         case (i@Invalid(_), Valid(_)) => i
-    *         case (Valid(_), i@Invalid(_)) => i
-    *         case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
-    *       }
+    *  new Applicative[Validated[E, ?]] {
+    *    def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
+    *      (fa, f) match {
+    *        case (Valid(a), Valid(fab)) => Valid(fab(a))
+    *        case (i@Invalid(_), Valid(_)) => i
+    *        case (Valid(_), i@Invalid(_)) => i
+    *        case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
+    *      }
     *
-    *     def pure[A](x: A): Validated[E, A] = Validated.valid(x)
-    *     def map[A, B](fa: Validated[E, A])(f: A => B): Validated[E, B] = fa.map(f)
-    *     def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
-    *       ap(fa.map(a => (b: B) => (a, b)))(fb)
-    *   }
+    *    def pure[A](x: A): Validated[E, A] = Validated.valid(x)
+    *    def map[A, B](fa: Validated[E, A])(f: A => B): Validated[E, B] = fa.map(f)
+    *    def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
+    *      ap(fa.map(a => (b: B) => (a, b)))(fb)
+    *  }
     * }}}
     *
     * Awesome! And now we also get access to all the goodness of `Applicative`, which includes `map{2-22}`, as well as the
@@ -243,7 +239,7 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     * import cats.data.ValidatedNel
     *
     * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
-    *   SemigroupK[NonEmptyList].algebra[ConfigError]
+    *  SemigroupK[NonEmptyList].algebra[ConfigError]
     *
     * val config = Config(Map(("name", "cat"), ("age", "not a number"), ("houseNumber", "1234"), ("lane", "feline street")))
     *
@@ -255,12 +251,12 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * val personFromConfig: ValidatedNel[ConfigError, Person] =
-    *   Apply[ValidatedNel[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNel,
-    *                                            config.parse[Int]("age").toValidatedNel,
-    *                                            config.parse[Int]("house_number").toValidatedNel,
-    *                                            config.parse[String]("street").toValidatedNel) {
-    *     case (name, age, houseNumber, street) => Person(name, age, Address(houseNumber, street))
-    *   }
+    *  Apply[ValidatedNel[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNel,
+    *                                           config.parse[Int]("age").toValidatedNel,
+    *                                           config.parse[Int]("house_number").toValidatedNel,
+    *                                           config.parse[String]("street").toValidatedNel) {
+    *    case (name, age, houseNumber, street) => Person(name, age, Address(houseNumber, street))
+    *  }
     *
     * We can now rewrite validations in terms of `Apply`.
     *
@@ -273,29 +269,29 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     * import cats.Monad
     *
     * implicit def validatedMonad[E]: Monad[Validated[E, ?]] =
-    *   new Monad[Validated[E, ?]] {
-    *     def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
-    *       fa match {
-    *         case Valid(a)     => f(a)
-    *         case i@Invalid(_) => i
-    *       }
+    *  new Monad[Validated[E, ?]] {
+    *    def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
+    *      fa match {
+    *        case Valid(a)     => f(a)
+    *        case i@Invalid(_) => i
+    *      }
     *
-    *     def pure[A](x: A): Validated[E, A] = Valid(x)
-    *   }
+    *    def pure[A](x: A): Validated[E, A] = Valid(x)
+    *  }
     * }}}
     *
     * Note that all `Monad` instances are also `Applicative` instances, where `ap` is defined as
     *
     * {{{
     * trait Monad[F[_]] {
-    *   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
-    *   def pure[A](x: A): F[A]
+    *  def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+    *  def pure[A](x: A): F[A]
     *
-    *   def map[A, B](fa: F[A])(f: A => B): F[B] =
-    *     flatMap(fa)(f.andThen(pure))
+    *  def map[A, B](fa: F[A])(f: A => B): F[B] =
+    *    flatMap(fa)(f.andThen(pure))
     *
-    *   def ap[A, B](fa: F[A])(f: F[A => B]): F[B] =
-    *     flatMap(fa)(a => map(f)(fab => fab(a)))
+    *  def ap[A, B](fa: F[A])(f: F[A => B]): F[B] =
+    *    flatMap(fa)(a => map(f)(fab => fab(a)))
     * }
     * }}}
     *
@@ -326,9 +322,9 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     * }}}
     */
   def sequentialValidation(res0: Boolean, res1: Boolean) = {
-    val config = Config(Map("house_number" -> "-42"))
+    val config = Config(Map("house_number" → "-42"))
 
-    val houseNumber = config.parse[Int]("house_number").andThen{ n =>
+    val houseNumber = config.parse[Int]("house_number").andThen { n ⇒
       if (n >= 0) Validated.valid(n)
       else Validated.invalid(ParseError("house_number"))
     }
@@ -338,8 +334,7 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     houseNumber == Validated.invalid(error) should be(res1)
   }
 
-  /**
-    * == `withXor` ==
+  /** == `withXor` ==
     *
     * The `withXor` method allows you to temporarily turn a `Validated` instance into an `Xor` instance and apply it to a function.
     *
@@ -347,8 +342,8 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     * import cats.data.Xor
     *
     * def positive(field: String, i: Int): ConfigError Xor Int = {
-    *   if (i >= 0) Xor.right(i)
-    *   else Xor.left(ParseError(field))
+    *  if (i >= 0) Xor.right(i)
+    *  else Xor.left(ParseError(field))
     * }
     * }}}
     *
@@ -356,10 +351,10 @@ object ValidatedSection extends FlatSpec with Matchers with exercise.Section {
     *
     */
   def validatedAsXor(res0: Boolean, res1: Boolean) = {
-    val config = Config(Map("house_number" -> "-42"))
+    val config = Config(Map("house_number" → "-42"))
 
-    val houseNumber = config.parse[Int]("house_number").withXor{ xor: ConfigError Xor Int =>
-      xor.flatMap{ i =>
+    val houseNumber = config.parse[Int]("house_number").withXor { xor: ConfigError Xor Int ⇒
+      xor.flatMap { i ⇒
         positive("house_number", i)
       }
     }

--- a/site/content/src/main/scala/catslib/ValidatedHelpers.scala
+++ b/site/content/src/main/scala/catslib/ValidatedHelpers.scala
@@ -3,7 +3,7 @@ package catslib
 import cats.{ Semigroup, SemigroupK }
 import cats.data.NonEmptyList
 import cats.data.Validated
-import cats.data.Validated.{Invalid, Valid}
+import cats.data.Validated.{ Invalid, Valid }
 import cats.data.Xor
 import cats.std.list._
 
@@ -33,28 +33,28 @@ object ValidatedHelpers {
   final case class ParseError(field: String) extends ConfigError
 
   import cats.data.Validated
-  import cats.data.Validated.{Invalid, Valid}
+  import cats.data.Validated.{ Invalid, Valid }
 
   case class Config(map: Map[String, String]) {
-    def parse[A : Read](key: String): Validated[ConfigError, A] =
+    def parse[A: Read](key: String): Validated[ConfigError, A] =
       map.get(key) match {
-        case None        => Invalid(MissingConfig(key))
-        case Some(value) =>
+        case None ⇒ Invalid(MissingConfig(key))
+        case Some(value) ⇒
           Read[A].read(value) match {
-            case None    => Invalid(ParseError(key))
-            case Some(a) => Valid(a)
+            case None    ⇒ Invalid(ParseError(key))
+            case Some(a) ⇒ Valid(a)
           }
       }
   }
 
   import cats.Semigroup
 
-  def parallelValidate[E : Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
+  def parallelValidate[E: Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) ⇒ C): Validated[E, C] =
     (v1, v2) match {
-      case (Valid(a), Valid(b))       => Valid(f(a, b))
-      case (Valid(_), i@Invalid(_))   => i
-      case (i@Invalid(_), Valid(_))   => i
-      case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
+      case (Valid(a), Valid(b))       ⇒ Valid(f(a, b))
+      case (Valid(_), i @ Invalid(_)) ⇒ i
+      case (i @ Invalid(_), Valid(_)) ⇒ i
+      case (Invalid(e1), Invalid(e2)) ⇒ Invalid(Semigroup[E].combine(e1, e2))
     }
 
   import cats.SemigroupK

--- a/site/content/src/main/scala/catslib/XorSection.scala
+++ b/site/content/src/main/scala/catslib/XorSection.scala
@@ -79,8 +79,8 @@ object XorStyleWithAdts {
   * sealed abstract class Xor[+A, +B]
   *
   * object Xor {
-  *   final case class Left[+A](a: A) extends Xor[A, Nothing]
-  *   final case class Right[+B](b: B) extends Xor[Nothing, B]
+  *  final case class Left[+A](a: A) extends Xor[A, Nothing]
+  *  final case class Right[+B](b: B) extends Xor[Nothing, B]
   * }
   * }}}
   *
@@ -139,12 +139,12 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     * import cats.Monad
     *
     * implicit def xorMonad[Err]: Monad[Xor[Err, ?]] =
-    *   new Monad[Xor[Err, ?]] {
-    *     def flatMap[A, B](fa: Xor[Err, A])(f: A => Xor[Err, B]): Xor[Err, B] =
-    *       fa.flatMap(f)
+    *  new Monad[Xor[Err, ?]] {
+    *    def flatMap[A, B](fa: Xor[Err, A])(f: A => Xor[Err, B]): Xor[Err, B] =
+    *      fa.flatMap(f)
     *
-    *     def pure[A](x: A): Xor[Err, A] = Xor.right(x)
-    *   }
+    *    def pure[A](x: A): Xor[Err, A] = Xor.right(x)
+    *  }
     * }}}
     *
     * So the `flatMap` method is right-biased:
@@ -154,10 +154,10 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     import cats.data.Xor
 
     val right: String Xor Int = Xor.right(5)
-    right.flatMap(x => Xor.right(x + 1)) should be(Xor.right(res0))
+    right.flatMap(x ⇒ Xor.right(x + 1)) should be(Xor.right(res0))
 
     val left: String Xor Int = Xor.left("Something went wrong")
-    left.flatMap(x => Xor.right(x + 1)) should be(Xor.left(res1))
+    left.flatMap(x ⇒ Xor.right(x + 1)) should be(Xor.left(res1))
   }
 
   /** = Using `Xor` instead of exceptions =
@@ -169,15 +169,15 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object ExceptionStyle {
-    *   def parse(s: String): Int =
-    *     if (s.matches("-?[0-9]+")) s.toInt
-    *     else throw new NumberFormatException(s"${s} is not a valid integer.")
+    *  def parse(s: String): Int =
+    *    if (s.matches("-?[0-9]+")) s.toInt
+    *    else throw new NumberFormatException(s"${s} is not a valid integer.")
     *
-    *   def reciprocal(i: Int): Double =
-    *     if (i == 0) throw new IllegalArgumentException("Cannot take reciprocal of 0.")
-    *     else 1.0 / i
+    *  def reciprocal(i: Int): Double =
+    *    if (i == 0) throw new IllegalArgumentException("Cannot take reciprocal of 0.")
+    *    else 1.0 / i
     *
-    *   def stringify(d: Double): String = d.toString
+    *  def stringify(d: Double): String = d.toString
     *
     * }
     * }}}
@@ -186,18 +186,18 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object XorStyle {
-    *   def parse(s: String): Xor[NumberFormatException, Int] =
-    *     if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
-    *     else Xor.left(new NumberFormatException(s"${s} is not a valid integer."))
+    *  def parse(s: String): Xor[NumberFormatException, Int] =
+    *    if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
+    *    else Xor.left(new NumberFormatException(s"${s} is not a valid integer."))
     *
-    *   def reciprocal(i: Int): Xor[IllegalArgumentException, Double] =
-    *     if (i == 0) Xor.left(new IllegalArgumentException("Cannot take reciprocal of 0."))
-    *     else Xor.right(1.0 / i)
+    *  def reciprocal(i: Int): Xor[IllegalArgumentException, Double] =
+    *    if (i == 0) Xor.left(new IllegalArgumentException("Cannot take reciprocal of 0."))
+    *    else Xor.right(1.0 / i)
     *
-    *   def stringify(d: Double): String = d.toString
+    *  def stringify(d: Double): String = d.toString
     *
-    *   def magic(s: String): Xor[Exception, String] =
-    *     parse(s).flatMap(reciprocal).map(stringify)
+    *  def magic(s: String): Xor[Exception, String] =
+    *    parse(s).flatMap(reciprocal).map(stringify)
     * }
     * }}}
     *
@@ -215,9 +215,9 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
   def xorComposition(res0: Boolean, res1: Boolean, res2: Boolean) = {
     import XorStyle._
 
-    magic("0").isRight should be (res0)
-    magic("1").isRight should be (res1)
-    magic("Not a number").isRight should be (res2)
+    magic("0").isRight should be(res0)
+    magic("1").isRight should be(res1)
+    magic("Not a number").isRight should be(res2)
   }
 
   /** With the composite function that we actually care about, we can pass in strings and then pattern
@@ -237,10 +237,10 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     import XorStyle._
 
     val result = magic("2") match {
-      case Xor.Left(_: NumberFormatException)    => "Not a number!"
-      case Xor.Left(_: IllegalArgumentException) => "Can't take reciprocal of 0!"
-      case Xor.Left(_)                           => "Unknown error"
-      case Xor.Right(result)                     => s"Got reciprocal: ${result}"
+      case Xor.Left(_: NumberFormatException)    ⇒ "Not a number!"
+      case Xor.Left(_: IllegalArgumentException) ⇒ "Can't take reciprocal of 0!"
+      case Xor.Left(_)                           ⇒ "Unknown error"
+      case Xor.Right(result)                     ⇒ s"Got reciprocal: ${result}"
     }
     result should be(res0)
   }
@@ -250,22 +250,22 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object XorStyleWithAdts {
-    *   sealed abstract class Error
-    *   final case class NotANumber(string: String) extends Error
-    *   final case object NoZeroReciprocal extends Error
+    *  sealed abstract class Error
+    *  final case class NotANumber(string: String) extends Error
+    *  final case object NoZeroReciprocal extends Error
     *
-    *   def parse(s: String): Xor[Error, Int] =
-    *     if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
-    *     else Xor.left(NotANumber(s))
+    *  def parse(s: String): Xor[Error, Int] =
+    *    if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
+    *    else Xor.left(NotANumber(s))
     *
-    *   def reciprocal(i: Int): Xor[Error, Double] =
-    *     if (i == 0) Xor.left(NoZeroReciprocal)
-    *     else Xor.right(1.0 / i)
+    *  def reciprocal(i: Int): Xor[Error, Double] =
+    *    if (i == 0) Xor.left(NoZeroReciprocal)
+    *    else Xor.right(1.0 / i)
     *
-    *   def stringify(d: Double): String = d.toString
+    *  def stringify(d: Double): String = d.toString
     *
-    *   def magic(s: String): Xor[Error, String] =
-    *     parse(s).flatMap(reciprocal).map(stringify)
+    *  def magic(s: String): Xor[Error, String] =
+    *    parse(s).flatMap(reciprocal).map(stringify)
     * }
     * }}}
     *
@@ -279,9 +279,9 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     import XorStyleWithAdts._
 
     val result = magic("2") match {
-      case Xor.Left(NotANumber(_))    => "Not a number!"
-      case Xor.Left(NoZeroReciprocal) => "Can't take reciprocal of 0!"
-      case Xor.Right(result)          => s"Got reciprocal: ${result}"
+      case Xor.Left(NotANumber(_))    ⇒ "Not a number!"
+      case Xor.Left(NoZeroReciprocal) ⇒ "Can't take reciprocal of 0!"
+      case Xor.Right(result)          ⇒ s"Got reciprocal: ${result}"
     }
     result should be(res0)
   }
@@ -296,14 +296,14 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     * trait DatabaseValue
     *
     * object Database {
-    *   def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
+    *  def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
     * }
     *
     * sealed abstract class ServiceError
     * trait ServiceValue
     *
     * object Service {
-    *   def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
+    *  def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
     * }
     * }}}
     *
@@ -338,11 +338,11 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     * trait DatabaseValue
     *
     * object Database {
-    *   def databaseThings(): Xor[AppError, DatabaseValue] = ???
+    *  def databaseThings(): Xor[AppError, DatabaseValue] = ???
     * }
     *
     * object Service {
-    *   def serviceThings(v: DatabaseValue): Xor[AppError, ServiceValue] = ???
+    *  def serviceThings(v: DatabaseValue): Xor[AppError, ServiceValue] = ???
     * }
     *
     * def doApp = Database.databaseThings().flatMap(Service.serviceThings)
@@ -363,20 +363,20 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     * trait DatabaseValue
     *
     * object Database {
-    *   def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
+    *  def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
     * }
     *
     * sealed abstract class ServiceError
     * trait ServiceValue
     *
     * object Service {
-    *   def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
+    *  def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
     * }
     *
     * sealed abstract class AppError
     * object AppError {
-    *   final case class Database(error: DatabaseError) extends AppError
-    *   final case class Service(error: ServiceError) extends AppError
+    *  final case class Database(error: DatabaseError) extends AppError
+    *  final case class Service(error: ServiceError) extends AppError
     * }
     * }}}
     *
@@ -386,8 +386,8 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * def doApp: Xor[AppError, ServiceValue] =
-    *   Database.databaseThings().leftMap(AppError.Database).
-    *   flatMap(dv => Service.serviceThings(dv).leftMap(AppError.Service))
+    *  Database.databaseThings().leftMap(AppError.Database).
+    *  flatMap(dv => Service.serviceThings(dv).leftMap(AppError.Service))
     * }}}
     *
     * Hurrah! Each module only cares about its own errors as it should be, and more composite modules have their
@@ -396,11 +396,11 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * def awesome =
-    *   doApp match {
-    *     case Xor.Left(AppError.Database(_)) => "something in the database went wrong"
-    *     case Xor.Left(AppError.Service(_))  => "something in the service went wrong"
-    *     case Xor.Right(_)                   => "everything is alright!"
-    *   }
+    *  doApp match {
+    *    case Xor.Left(AppError.Database(_)) => "something in the database went wrong"
+    *    case Xor.Left(AppError.Service(_))  => "something in the service went wrong"
+    *    case Xor.Right(_)                   => "everything is alright!"
+    *  }
     * }}}
     *
     * Let's review the `leftMap` and `map` methods:
@@ -408,11 +408,11 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     */
   def xorInTheLarge(res0: Int, res1: String, res2: String) = {
     val right: String Xor Int = Xor.Right(41)
-    right.map(_ + 1) should be (Xor.Right(res0))
+    right.map(_ + 1) should be(Xor.Right(res0))
 
     val left: String Xor Int = Xor.Left("Hello")
-    left.map(_ + 1) should be (Xor.Left(res1))
-    left.leftMap(_.reverse) should be (Xor.Left(res2))
+    left.map(_ + 1) should be(Xor.Left(res1))
+    left.leftMap(_.reverse) should be(Xor.Left(res2))
   }
 
   /** There will inevitably come a time when your nice `Xor` code will have to interact with exception-throwing
@@ -420,11 +420,11 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * val xor: Xor[NumberFormatException, Int] =
-    *   try {
-    *     Xor.right("abc".toInt)
-    *   } catch {
-    *     case nfe: NumberFormatException => Xor.left(nfe)
-    *   }
+    *  try {
+    *    Xor.right("abc".toInt)
+    *  } catch {
+    *    case nfe: NumberFormatException => Xor.left(nfe)
+    *  }
     * }}}
     *
     * However, this can get tedious quickly. `Xor` provides a `catchOnly` method on its companion object
@@ -433,7 +433,7 @@ object XorSection extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * val xor: Xor[NumberFormatException, Int] =
-    *   Xor.catchOnly[NumberFormatException]("abc".toInt)
+    *  Xor.catchOnly[NumberFormatException]("abc".toInt)
     * }}}
     *
     * If you want to catch all (non-fatal) throwables, you can use `catchNonFatal`.

--- a/site/content/src/main/scala/shapeless/ArityExercises.scala
+++ b/site/content/src/main/scala/shapeless/ArityExercises.scala
@@ -4,19 +4,18 @@ import org.scalatest._
 import shapeless._
 import ops.hlist._
 
-/**  
-  * Conversions between tuples and HList's, and between ordinary Scala functions of arbitrary arity and functions which 
-  * take a single corresponding HList argument allow higher order functions to abstract over the arity of the functions 
+/** Conversions between tuples and HList's, and between ordinary Scala functions of arbitrary arity and functions which
+  * take a single corresponding HList argument allow higher order functions to abstract over the arity of the functions
   * and values they are passed,
   * {{{
   * import syntax.std.function._
   * import ops.function._
-  * 
+  *
   * def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)
-  *   (implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L => R]) =
-  *     f.toProduct(gen.to(p))
+  *  (implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L => R]) =
+  *    f.toProduct(gen.to(p))
   * }}}
-  * 
+  *
   * @param name arity
   */
 object ArityExercises extends FlatSpec with Matchers with exercise.Section {
@@ -26,9 +25,8 @@ object ArityExercises extends FlatSpec with Matchers with exercise.Section {
 
   object Helper {
 
-  def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)
-  (implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L => R]) =
-    f.toProduct(gen.to(p))
+    def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)(implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L ⇒ R]) =
+      f.toProduct(gen.to(p))
 
   }
 
@@ -36,10 +34,9 @@ object ArityExercises extends FlatSpec with Matchers with exercise.Section {
 
   /** Abstracting over arity
     */
-  def arityTest(res0 : Int, res1 : Int) = {
-    applyProduct(1, 2)((_: Int)+(_: Int)) should be (res0)
-    applyProduct(1, 2, 3)((_: Int)*(_: Int)*(_: Int)) should be (res1)
+  def arityTest(res0: Int, res1: Int) = {
+    applyProduct(1, 2)((_: Int) + (_: Int)) should be(res0)
+    applyProduct(1, 2, 3)((_: Int) * (_: Int) * (_: Int)) should be(res1)
   }
-
 
 }

--- a/site/content/src/main/scala/shapeless/CoproductExercises.scala
+++ b/site/content/src/main/scala/shapeless/CoproductExercises.scala
@@ -3,11 +3,11 @@ package shapelessex
 import org.scalatest._
 import shapeless._
 
-/** shapeless has a Coproduct type, a generalization of Scala's Either to an arbitrary number of choices. 
-  * Currently it exists primarily to support Generic (see the next section), but will be expanded analogously 
-  * to HList in later releases. 
-  * 
-  * Currently Coproduct supports mapping, selection and unification, 
+/** shapeless has a Coproduct type, a generalization of Scala's Either to an arbitrary number of choices.
+  * Currently it exists primarily to support Generic (see the next section), but will be expanded analogously
+  * to HList in later releases.
+  *
+  * Currently Coproduct supports mapping, selection and unification,
   *
   * @param name coproducts
   */
@@ -17,9 +17,9 @@ object CoproductExercises extends FlatSpec with Matchers with exercise.Section {
     type ISB = Int :+: String :+: Boolean :+: CNil
 
     object sizeM extends Poly1 {
-      implicit def caseInt = at[Int](i => (i, i))
-      implicit def caseString = at[String](s => (s, s.length))
-      implicit def caseBoolean = at[Boolean](b => (b, 1))
+      implicit def caseInt = at[Int](i ⇒ (i, i))
+      implicit def caseString = at[String](s ⇒ (s, s.length))
+      implicit def caseBoolean = at[Boolean](b ⇒ (b, 1))
     }
 
     val isb = Coproduct[ISB]("foo")
@@ -27,47 +27,46 @@ object CoproductExercises extends FlatSpec with Matchers with exercise.Section {
 
   import Helper._
 
-  /** 
-    * {{{
+  /** {{{
     * type ISB = Int :+: String :+: Boolean :+: CNil
-    * 
-    * val isb = Coproduct[ISB]("foo") 
+    *
+    * val isb = Coproduct[ISB]("foo")
     * }}}
     */
-  def selection(res0 : Option[Int], res1 : Option[String]) = {
-    isb.select[Int] should be (res0)
+  def selection(res0: Option[Int], res1: Option[String]) = {
+    isb.select[Int] should be(res0)
 
-    isb.select[String] should be (res1)
+    isb.select[String] should be(res1)
   }
 
   /** Coproduct also supports mapping given a polymorphic function such as
     * {{{
     * object sizeM extends Poly1 {
-    *   implicit def caseInt = at[Int](i => (i, i))
-    *   implicit def caseString = at[String](s => (s, s.length))
-    *   implicit def caseBoolean = at[Boolean](b => (b, 1))
+    *  implicit def caseInt = at[Int](i => (i, i))
+    *  implicit def caseString = at[String](s => (s, s.length))
+    *  implicit def caseBoolean = at[Boolean](b => (b, 1))
     * }
     * }}}
     */
-  def mapping(res0 : Option[(String, Int)]) = {
+  def mapping(res0: Option[(String, Int)]) = {
     val m = isb map sizeM
 
-    m.select[(String, Int)] should be (res0)
+    m.select[(String, Int)] should be(res0)
   }
 
-  /** In the same way that adding labels To the elements of an HList gives us a record, 
+  /** In the same way that adding labels To the elements of an HList gives us a record,
     * adding labels to the elements of a Coproduct gives us a discriminated union.
     */
-  def unionE(res0 : Option[Int], res1 : Option[String], res2 : Option[Boolean]) = {
+  def unionE(res0: Option[Int], res1: Option[String], res2: Option[Boolean]) = {
     import record._, union._, syntax.singleton._
 
     type U = Union.`'i -> String, 's -> String, 'b -> Boolean`.T
 
     val u = Coproduct[U]('s ->> "foo") // Inject a String into the union at label 's
 
-    u.get('i) should be (res0)
-    u.get('s) should be (res1)
-    u.get('b) should be (res2)
+    u.get('i) should be(res0)
+    u.get('s) should be(res1)
+    u.get('b) should be(res2)
   }
 
 }

--- a/site/content/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
+++ b/site/content/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
@@ -4,43 +4,42 @@ import org.scalatest._
 import shapeless._
 import ops.hlist._
 
-/**  
-  * shapeless provides an implementation of extensible records modelled as `HList`s of values tagged with the singleton types of their keys.
-  * This means that there is no concrete representation needed at all for the keys. 
-  * Amongst other things this will allow subsequent work on `Generic` to map case classes directly to records with their member names 
+/** shapeless provides an implementation of extensible records modelled as `HList`s of values tagged with the singleton types of their keys.
+  * This means that there is no concrete representation needed at all for the keys.
+  * Amongst other things this will allow subsequent work on `Generic` to map case classes directly to records with their member names
   * encoded in their element types.
   * {{{
   * import shapeless._ ; import syntax.singleton._ ; import record._
-  * 
+  *
   * val book =
-  *   ("author" ->> "Benjamin Pierce") ::
-  *   ("title"  ->> "Types and Programming Languages") ::
-  *   ("id"     ->>  262162091) ::
-  *   ("price"  ->>  44.11) ::
-  *   HNil
+  *  ("author" ->> "Benjamin Pierce") ::
+  *  ("title"  ->> "Types and Programming Languages") ::
+  *  ("id"     ->>  262162091) ::
+  *  ("price"  ->>  44.11) ::
+  *  HNil
   * }}}
   *
   * @param name extensible_records
-  * 
+  *
   */
 object ExtensibleRecordsExercises extends FlatSpec with Matchers with exercise.Section {
 
-  import shapeless._ ; import syntax.singleton._ ; import record._
+  import shapeless._; import syntax.singleton._; import record._
 
   val book =
-     ("author" ->> "Benjamin Pierce") ::
-     ("title"  ->> "Types and Programming Languages") ::
-     ("id"     ->>  262162091) ::
-     ("price"  ->>  44.11) ::
-  HNil
+    ("author" ->> "Benjamin Pierce") ::
+      ("title" ->> "Types and Programming Languages") ::
+      ("id" ->> 262162091) ::
+      ("price" ->> 44.11) ::
+      HNil
 
   /**
-  */
-  def resultTypes(res0 : String, res1 : String, res2 : Int, res3 : Double) = {
-    book("author") should be (res0)
-    book("title") should be (res1)
-    book("id") should be (res2)
-    book("price") should be (res3)
+    */
+  def resultTypes(res0: String, res1: String, res2: Int, res3: Double) = {
+    book("author") should be(res0)
+    book("title") should be(res1)
+    book("id") should be(res2)
+    book("price") should be(res3)
   }
 
   /*
@@ -50,28 +49,27 @@ object ExtensibleRecordsExercises extends FlatSpec with Matchers with exercise.S
     book.keys should be (res0)
   }
    */
-  /** values 
+  /** values
     */
-  def values(res0 : String :: String :: Int :: Double :: HNil) = {
-    book.values should be (res0)
+  def values(res0: String :: String :: Int :: Double :: HNil) = {
+    book.values should be(res0)
   }
-   
 
-  /**  Update, Add or remove a field
+  /** Update, Add or remove a field
     */
-  def updated(res0 : Double, res1 : Boolean, res2 : String :: String :: Double :: HNil) = {
+  def updated(res0: Double, res1: Boolean, res2: String :: String :: Double :: HNil) = {
     val newPrice = book("price") + 2.0
-    val updated = book +("price" ->> newPrice)
+    val updated = book + ("price" ->> newPrice)
 
-    updated("price") should be (res0)
+    updated("price") should be(res0)
 
     val extended = updated + ("inPrint" ->> true)
 
-    extended("inPrint") should be (res0)
+    extended("inPrint") should be(res0)
 
     val noId = extended - "id"
 
-    noId.values should be (res2)
+    noId.values should be(res2)
 
     //noId("id")  // Attempting to access a missing field is a compile time error
     // error: could not find implicit value for parameter selector ...

--- a/site/content/src/main/scala/shapeless/GenericExercises.scala
+++ b/site/content/src/main/scala/shapeless/GenericExercises.scala
@@ -3,11 +3,11 @@ package shapelessex
 import org.scalatest._
 import shapeless._
 
-/** The Isos of earlier shapeless releases have been completely reworked as the new Generic type, 
+/** The Isos of earlier shapeless releases have been completely reworked as the new Generic type,
   * which closely resembles the generic programming capabilities introduced to GHC 7.2.
-  * Generic[T], where T is a case class or an abstract type at the root of a case class hierarchy, 
+  * Generic[T], where T is a case class or an abstract type at the root of a case class hierarchy,
   * maps between values of T and a generic sum of products representation (HLists and Coproducts),
-  * 
+  *
   * @param name generic
   */
 object GenericExercises extends FlatSpec with Matchers with exercise.Section {
@@ -15,7 +15,7 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
   case class Foo(i: Int, s: String, b: Boolean)
 
   object Helper {
-    
+
     val fooGen = Generic[Foo]
 
     val foo = Foo(23, "foo", true)
@@ -29,21 +29,22 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
 
     // Polymorphic function which adds 1 to any Int and is the identity
     // on all other values
+    // format: OFF
     object inc extends ->((i: Int) => i+1)
-
+    // format: ON
   }
 
   import Helper._
 
   /** {{{
     * case class Foo(i: Int, s: String, b: Boolean)
-    * 
+    *
     * val fooGen = Generic[Foo]
-    * 
+    *
     * val foo = Foo(23, "foo", true)
     * }}}
-    * 
-    * We can convert back and forth case class to their HList Generic representation  
+    *
+    * We can convert back and forth case class to their HList Generic representation
     */
   def genericE(res0 : fooGen.Repr, res1 : Int) = {
     val l = fooGen.to(foo)
@@ -53,25 +54,25 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
     newFoo.i should be (res1)
   }
 
-  /** Typically values of Generic for a given case class are materialized using an implicit macro, 
-    * allowing a wide variety of structural programming problems to be solved with no or minimal boilerplate. 
-    * In particular the existing lens, Scrap Your Boilerplate and generic zipper implementations are now available 
+  /** Typically values of Generic for a given case class are materialized using an implicit macro,
+    * allowing a wide variety of structural programming problems to be solved with no or minimal boilerplate.
+    * In particular the existing lens, Scrap Your Boilerplate and generic zipper implementations are now available
     * for any case class family (recursive families included, as illustrated below) without any additional boilerplate being required
     * {{{
     * import poly._
-    * 
+    *
     * // Simple recursive case class family
     * sealed trait Tree[T]
     * case class Leaf[T](t: T) extends Tree[T]
     * case class Node[T](left: Tree[T], right: Tree[T]) extends Tree[T]
-    * 
+    *
     * // Polymorphic function which adds 1 to any Int and is the identity
     * // on all other values
     * object inc extends ->((i: Int) => i+1)
     * }}}
     */
   def structural(res0 : Int, res1 : Int, res2 : Int) = {
-    
+
     val tree: Tree[Int] =
           Node(
             Leaf(1),
@@ -89,11 +90,11 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
     )
   }
 
-  /** A natural extension of Generic's mapping of the content of data types onto a sum of products representation 
-    * is to a mapping of the data type including its constructor and field names onto a labelled sum of products representation, 
-    * ie. a representation in terms of the discriminated unions and records that we saw above. 
-    * This is provided by LabelledGeneric. Currently it provides the underpinnings for the use of shapeless lenses with 
-    * symbolic path selectors (see next section) and it is expected that it will support many scenarios which would otherwise 
+  /** A natural extension of Generic's mapping of the content of data types onto a sum of products representation
+    * is to a mapping of the data type including its constructor and field names onto a labelled sum of products representation,
+    * ie. a representation in terms of the discriminated unions and records that we saw above.
+    * This is provided by LabelledGeneric. Currently it provides the underpinnings for the use of shapeless lenses with
+    * symbolic path selectors (see next section) and it is expected that it will support many scenarios which would otherwise
     * require the support of hard to maintain special case macros.
     */
   def labelled() = {

--- a/site/content/src/main/scala/shapeless/GenericExercises.scala
+++ b/site/content/src/main/scala/shapeless/GenericExercises.scala
@@ -46,12 +46,12 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
     *
     * We can convert back and forth case class to their HList Generic representation
     */
-  def genericE(res0 : fooGen.Repr, res1 : Int) = {
+  def genericE(res0: fooGen.Repr, res1: Int) = {
     val l = fooGen.to(foo)
-    l should be (res0)
+    l should be(res0)
     val r = 13 :: l.tail
     val newFoo = fooGen.from(r)
-    newFoo.i should be (res1)
+    newFoo.i should be(res1)
   }
 
   /** Typically values of Generic for a given case class are materialized using an implicit macro,
@@ -71,22 +71,26 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
     * object inc extends ->((i: Int) => i+1)
     * }}}
     */
-  def structural(res0 : Int, res1 : Int, res2 : Int) = {
+  def structural(res0: Int, res1: Int, res2: Int) = {
 
     val tree: Tree[Int] =
-          Node(
-            Leaf(1),
-            Node(
-              Leaf(2),
-              Leaf(3)))
+      Node(
+        Leaf(1),
+        Node(
+          Leaf(2),
+          Leaf(3)
+        )
+      )
 
     // Transform tree by applying inc everywhere
-    everywhere(inc)(tree) should be (
+    everywhere(inc)(tree) should be(
       Node(
-            Leaf(res0),
-            Node(
-              Leaf(res1),
-              Leaf(res2)))
+        Leaf(res0),
+        Node(
+          Leaf(res1),
+          Leaf(res2)
+        )
+      )
     )
   }
 
@@ -98,7 +102,6 @@ object GenericExercises extends FlatSpec with Matchers with exercise.Section {
     * require the support of hard to maintain special case macros.
     */
   def labelled() = {
-
 
   }
 

--- a/site/content/src/main/scala/shapeless/HListExercises.scala
+++ b/site/content/src/main/scala/shapeless/HListExercises.scala
@@ -5,21 +5,18 @@ import shapeless._
 import ops.hlist._
 
 object size extends Poly1 {
-  implicit def caseInt = at[Int](x => 1)
+  implicit def caseInt = at[Int](x ⇒ 1)
   implicit def caseString = at[String](_.length)
-  implicit def caseTuple[T, U]
-    (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
-      at[(T, U)](t => size(t._1)+size(t._2))
+  implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
+    at[(T, U)](t ⇒ size(t._1) + size(t._2))
 }
 
 object addSize extends Poly2 {
-  implicit  def default[T](implicit st: shapelessex.size.Case.Aux[T, Int]) =
-    at[Int, T]{ (acc, t) => acc+size(t) }
-    }
+  implicit def default[T](implicit st: shapelessex.size.Case.Aux[T, Int]) =
+    at[Int, T] { (acc, t) ⇒ acc + size(t) }
+}
 
-
-/** 
-  * 
+/**
   * shapeless provides a comprehensive Scala `HList` which has many features not shared by other HList implementations.
   *
   * @param name heterogenous_lists
@@ -29,28 +26,28 @@ object HListExercises extends FlatSpec with Matchers with exercise.Section {
   /** It has a `map` operation, applying a polymorphic function value across its elements. This means that it subsumes both
     * typical `HList`'s and also `KList`'s (`HList`'s whose elements share a common outer type constructor).
     */
-  def exerciseMap(res0: Option[Int], res1 : Option[String]) = {
+  def exerciseMap(res0: Option[Int], res1: Option[String]) = {
     import poly._
 
     object choose extends (Set ~> Option) {
-      def apply[T](s : Set[T]) = s.headOption
+      def apply[T](s: Set[T]) = s.headOption
     }
 
     val sets = Set(1) :: Set("foo") :: HNil
 
     val opts = sets map choose
 
-    opts should be (res0 :: res1 :: HNil)
+    opts should be(res0 :: res1 :: HNil)
   }
 
   /** It also has a flatMap Operation
     */
-  def exerciseFlatMap(res0 : Int, res1 : String, res2 : Boolean) = {
+  def exerciseFlatMap(res0: Int, res1: String, res2: Boolean) = {
     import poly.identity
 
     val l = (23 :: "foo" :: HNil) :: HNil :: (true :: HNil) :: HNil
 
-    l flatMap identity should be (res0 :: res1 :: res2 :: HNil)
+    l flatMap identity should be(res0 :: res1 :: res2 :: HNil)
 
   }
 
@@ -63,25 +60,23 @@ object HListExercises extends FlatSpec with Matchers with exercise.Section {
     * }
     * }}}
     */
-  def exerciseFold(res0 : Int) = {
-
+  def exerciseFold(res0: Int) = {
 
     val l = 23 :: "foo" :: (13, "wibble") :: HNil
 
-    l.foldLeft(0)(addSize) should be (res0)
+    l.foldLeft(0)(addSize) should be(res0)
 
   }
 
-
   /** It also has a zipper for traversal and persistent update,
     */
-  def exerciseZipper(res0 : Int, res1 : (String, Int), res2 : Double, res3 : Int, res4 : String, res5 : String, res6 : Double) = {
+  def exerciseZipper(res0: Int, res1: (String, Int), res2: Double, res3: Int, res4: String, res5: String, res6: Double) = {
     import syntax.zipper._
 
     val l = 1 :: "foo" :: 3.0 :: HNil
-    l.toZipper.right.put(("wibble", 45)).reify should be (res0 :: res1 :: res2 :: HNil)
+    l.toZipper.right.put(("wibble", 45)).reify should be(res0 :: res1 :: res2 :: HNil)
 
-    l.toZipper.right.delete.reify should be (res3 :: res4 :: res5 :: res6 :: HNil)
+    l.toZipper.right.delete.reify should be(res3 :: res4 :: res5 :: res6 :: HNil)
 
   }
 
@@ -94,69 +89,69 @@ object HListExercises extends FlatSpec with Matchers with exercise.Section {
     type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
     type APAP = Apple :: Pear :: Apple :: Pear :: HNil
 
-    val a : Apple = Apple()
-    val p : Pear = Pear()
-     
-    val apap : APAP = a :: p :: a :: p :: HNil
+    val a: Apple = Apple()
+    val p: Pear = Pear()
+
+    val apap: APAP = a :: p :: a :: p :: HNil
   }
 
   import CovariantHelper._
 
   /** It is covariant,
     * {{{
-    *  object CovariantHelper {
-    *    
-    *  trait Fruit
-    *  case class Apple() extends Fruit
-    *  case class Pear() extends Fruit
-    * 
-    *  type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
-    *  type APAP = Apple :: Pear :: Apple :: Pear :: HNil
-    * 
-    *  val a : Apple = Apple()
-    *  val p : Pear = Pear()
-    * 
-    *  val apap : APAP = a :: p :: a :: p :: HNil
-    * 
+    * object CovariantHelper {
+    *
+    * trait Fruit
+    * case class Apple() extends Fruit
+    * case class Pear() extends Fruit
+    *
+    * type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
+    * type APAP = Apple :: Pear :: Apple :: Pear :: HNil
+    *
+    * val a : Apple = Apple()
+    * val p : Pear = Pear()
+    *
+    * val apap : APAP = a :: p :: a :: p :: HNil
+    *
     * }
     * }}}
     */
-  def exerciseCovariant(res0 : Boolean) = {
+  def exerciseCovariant(res0: Boolean) = {
     import scala.reflect.runtime.universe._
 
-    implicitly[TypeTag[APAP]].tpe.typeConstructor <:< typeOf[FFFF] should be (res0)
+    implicitly[TypeTag[APAP]].tpe.typeConstructor <:< typeOf[FFFF] should be(res0)
   }
 
   /** And it has a unify operation which converts it to an HList of elements of the least upper bound of the original types,
     */
-  def exerciseUnify(res0 : Boolean, res1 : Boolean) = {  
-    apap.isInstanceOf[FFFF] should be (res0) 
-    apap.unify.isInstanceOf[FFFF] should be (res1) 
+  def exerciseUnify(res0: Boolean, res1: Boolean) = {
+    apap.isInstanceOf[FFFF] should be(res0)
+    apap.unify.isInstanceOf[FFFF] should be(res1)
   }
 
   /** It supports conversion to an ordinary Scala List of elements of the least upper bound of the original types,
     */
-  def exerciseConversionToList(res0 : List[Fruit]) = {
-    apap.toList should be (res0)
+  def exerciseConversionToList(res0: List[Fruit]) = {
+    apap.toList should be(res0)
   }
 
-  /** And it has a Typeable type class instance (see below), allowing, eg. vanilla List[Any]'s or HList's with 
+  /** And it has a Typeable type class instance (see below), allowing, eg. vanilla List[Any]'s or HList's with
     * elements of type Any to be safely cast to precisely typed HList's.
     */
-  def exerciseTypeable(res0 : Option[APAP]) = {
+  def exerciseTypeable(res0: Option[APAP]) = {
     import syntax.typeable._
 
-    val ffff : FFFF = apap.unify
+    val ffff: FFFF = apap.unify
     val precise: Option[APAP] = ffff.cast[APAP]
 
-    precise should be (res0)
+    precise should be(res0)
 
-  /** These last three features make this HList dramatically more practically useful than HList's are typically thought to be: 
-    * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries. 
-    * This implementation supports the discarding of precise information where necessary. 
-    * (eg. to serialize a precisely typed record after construction), and its later reconstruction. 
-    * (eg. a weakly typed deserialized record with a known schema can have it's precise typing reestabilished).
-    */
+    /** These last three features make this HList dramatically more practically useful than HList's are typically thought to be:
+      * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries.
+      * This implementation supports the discarding of precise information where necessary.
+      * (eg. to serialize a precisely typed record after construction), and its later reconstruction.
+      * (eg. a weakly typed deserialized record with a known schema can have it's precise typing reestabilished).
+      */
   }
 
 }

--- a/site/content/src/main/scala/shapeless/HMapExercises.scala
+++ b/site/content/src/main/scala/shapeless/HMapExercises.scala
@@ -4,18 +4,17 @@ import org.scalatest._
 import shapeless._
 import ops.hlist._
 
-/** 
-  * Shapeless provides a heterogenous map which supports an arbitrary relation between the key type and the corresponding value type.
+/** Shapeless provides a heterogenous map which supports an arbitrary relation between the key type and the corresponding value type.
   * {{{
   * class BiMapIS[K, V]
-  *   implicit val intToString = new BiMapIS[Int, String]
-  *   implicit val stringToInt = new BiMapIS[String, Int]
-  * 
-  *   val hm = HMap[BiMapIS](23 -> "foo", "bar" -> 13)
-  *   //val hm2 = HMap[BiMapIS](23 -> "foo", 23 -> 13)   // Does not compile
-  *}}}
-  * 
-  *  @param name HMap 
+  *  implicit val intToString = new BiMapIS[Int, String]
+  *  implicit val stringToInt = new BiMapIS[String, Int]
+  *
+  *  val hm = HMap[BiMapIS](23 -> "foo", "bar" -> 13)
+  *  //val hm2 = HMap[BiMapIS](23 -> "foo", 23 -> 13)   // Does not compile
+  * }}}
+  *
+  * @param name HMap
   */
 object HMapExercises extends FlatSpec with Matchers with exercise.Section {
 
@@ -24,7 +23,7 @@ object HMapExercises extends FlatSpec with Matchers with exercise.Section {
     implicit val intToString = new BiMapIS[Int, String]
     implicit val stringToInt = new BiMapIS[String, Int]
 
-    val hm = HMap[BiMapIS](23 -> "foo", "bar" -> 13)
+    val hm = HMap[BiMapIS](23 → "foo", "bar" → 13)
     //val hm2 = HMap[BiMapIS](23 -> "foo", 23 -> 13)   // Does not compile
   }
 
@@ -33,18 +32,18 @@ object HMapExercises extends FlatSpec with Matchers with exercise.Section {
   /** Key/value relation to be enforced: Strings map to Ints and vice versa
     */
   def kvEnforcement(res0: Option[String], res1: Option[Int]) = {
-    hm.get(23) should be (res0)
-    hm.get("bar") should be (res1)
+    hm.get(23) should be(res0)
+    hm.get("bar") should be(res1)
   }
 
-  /** And in much the same way that an ordinary monomorphic Scala map can be viewed as a monomorphic function value, 
+  /** And in much the same way that an ordinary monomorphic Scala map can be viewed as a monomorphic function value,
     * so too can a heterogenous shapeless map be viewed as a polymorphic function value,
     */
-  def mapAsPolyFValue(res0 : String :: Int :: HNil) = {
+  def mapAsPolyFValue(res0: String :: Int :: HNil) = {
     import hm._
     val l = 23 :: "bar" :: HNil
     val m = l map hm
-    m should be (res0)
+    m should be(res0)
   }
 
 }

--- a/site/content/src/main/scala/shapeless/PolyExercises.scala
+++ b/site/content/src/main/scala/shapeless/PolyExercises.scala
@@ -2,21 +2,19 @@ package shapelessex
 
 import org.scalatest._
 import shapeless._
-import poly.{~>}
+import poly.{ ~> }
 
-/** 
-  * 
+/**
   * Ordinary Scala function values are monomorphic. shapeless, however, provides an encoding of polymorphic
   * function values. It supports natural transformations, which are familiar from libraries like Cats or Scalaz,
-  * 
+  *
   * @param name polymorphic_function_values
   */
 object PolyExercises extends FlatSpec with Matchers with exercise.Section {
 
   object choose extends (Set ~> Option) {
-      def apply[T](s : Set[T]) = s.headOption
-    }
-
+    def apply[T](s: Set[T]) = s.headOption
+  }
 
   /** choose is a function from Sets to Options with no type specific cases
     * {{{
@@ -29,7 +27,7 @@ object PolyExercises extends FlatSpec with Matchers with exercise.Section {
     import shapeless.poly._
     // choose is a function from Sets to Options with no type specific cases
 
-    choose(Set(1, 2, 3)) should be (res0)
+    choose(Set(1, 2, 3)) should be(res0)
     choose(Set('a', 'b', 'c')) should be(res1)
   }
 
@@ -43,18 +41,18 @@ object PolyExercises extends FlatSpec with Matchers with exercise.Section {
     * res2: (Option[Int], Option[Char]) = (Some(1),Some(a))
     * }}}
     */
-  def exercisePairApply(res0 : Option[Int], res1 : Option[Char]) = {
+  def exercisePairApply(res0: Option[Int], res1: Option[Char]) = {
     def pairApply(f: Set ~> Option) = (f(Set(1, 2, 3)), f(Set('a', 'b', 'c')))
 
-    pairApply(choose) should be (res0, res1)
+    pairApply(choose) should be(res0, res1)
   }
 
   /** They are nevertheless interoperable with ordinary monomorphic function values.
     * choose is convertible to an ordinary monomorphic function value and can be
     * mapped across an ordinary Scala List
     */
-  def exerciseMonomorphicChoose(res0 : Option[Int], res1 : Option[Int]) = {
-    (List(Set(1, 3, 5), Set(2, 4, 6)) map choose) should be (List(res1, res0))
+  def exerciseMonomorphicChoose(res0: Option[Int], res1: Option[Int]) = {
+    (List(Set(1, 3, 5), Set(2, 4, 6)) map choose) should be(List(res1, res0))
   }
 
   /** However, they are [more general than natural transformations][polyblog2] and are able to capture type-specific cases
@@ -62,19 +60,19 @@ object PolyExercises extends FlatSpec with Matchers with exercise.Section {
     * size is a function from Ints or Strings or pairs to a 'size' defined
     * by type specific cases
     */
-  def exerciseSize(res0 : Int, res1 : Int, res2 : Int, res3 : Int) = {
+  def exerciseSize(res0: Int, res1: Int, res2: Int, res3: Int) = {
 
     object size extends Poly1 {
-      implicit def caseInt = at[Int](x => 1)
+      implicit def caseInt = at[Int](x ⇒ 1)
       implicit def caseString = at[String](_.length)
-      implicit def caseTuple[T, U](implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
-        at[(T, U)](t => size(t._1)+size(t._2))
+      implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
+        at[(T, U)](t ⇒ size(t._1) + size(t._2))
     }
 
-    size(23) should be (res0)
-    size("foo") should be (res1)
-    size((23, "foo")) should be (res2)
-    size(((23, "foo"), 13)) should be (res3)
+    size(23) should be(res0)
+    size("foo") should be(res1)
+    size((23, "foo")) should be(res2)
+    size(((23, "foo"), 13)) should be(res3)
   }
 
 }

--- a/site/content/src/main/scala/shapeless/SingletonExercises.scala
+++ b/site/content/src/main/scala/shapeless/SingletonExercises.scala
@@ -3,31 +3,30 @@ package shapelessex
 import org.scalatest._
 import shapeless._
 
-/** 
-  * Singleton-typed literals
-  * 
-  * Although Scala's typechecker has always represented singleton types for literal values internally, 
-  * there has not previously been syntax available to express them, other than by modifying the compiler. 
-  * shapeless adds support for singleton-typed literals via implicit macros. 
-  * 
-  *  @param name singletons_literals
-  *   
+/** Singleton-typed literals
+  *
+  * Although Scala's typechecker has always represented singleton types for literal values internally,
+  * there has not previously been syntax available to express them, other than by modifying the compiler.
+  * shapeless adds support for singleton-typed literals via implicit macros.
+  *
+  * @param name singletons_literals
+  *
   */
 object SingletonExercises extends FlatSpec with Matchers with exercise.Section {
 
-  /** Singleton types bridge the gap between the value level and the type level and hence allow the exploration in Scala 
-    * of techniques which would typically only be available in languages with support for full-spectrum dependent types. 
-    * The latest iteration of shapeless records makes a start on that. 
+  /** Singleton types bridge the gap between the value level and the type level and hence allow the exploration in Scala
+    * of techniques which would typically only be available in languages with support for full-spectrum dependent types.
+    * The latest iteration of shapeless records makes a start on that.
     * Another simpler application is the use of Int literals to index into HLists and tuples,
     */
-  def indexHListAndTuples(res0 : String, res1 : String) = {
+  def indexHListAndTuples(res0: String, res1: String) = {
     import syntax.std.tuple._
 
     val l = 23 :: "foo" :: true :: HNil
-    l(1) should be (res0)
+    l(1) should be(res0)
 
     val t = (23, "foo", true)
-    t(1) should be (res1)
+    t(1) should be(res1)
   }
 
   import shapeless._, syntax.singleton._
@@ -36,20 +35,20 @@ object SingletonExercises extends FlatSpec with Matchers with exercise.Section {
     * {{{
     * import shapeless._, syntax.singleton._
     * }}}
-    */ 
-  def narrow1(res0 : Witness.`23`.T) = {
-    res0.isInstanceOf[Witness.`23`.T] should be (true)
+    */
+  def narrow1(res0: Witness.`23`.T) = {
+    res0.isInstanceOf[Witness.`23`.T] should be(true)
   }
 
   /**
     */
-  def narrow2(res0 : Witness.`"foo"`.T) = {
-    res0.isInstanceOf[Witness.`"foo"`.T] should be (true)
+  def narrow2(res0: Witness.`"foo"`.T) = {
+    res0.isInstanceOf[Witness.`"foo"`.T] should be(true)
   }
 
   /**
     */
-  def select(res0 : Int, res1 : String) = {
+  def select(res0: Int, res1: String) = {
     val (wTrue, wFalse) = (Witness(true), Witness(false))
 
     type True = wTrue.T
@@ -62,7 +61,7 @@ object SingletonExercises extends FlatSpec with Matchers with exercise.Section {
 
     def select(b: WitnessWith[Select])(t: b.instance.Out) = t
 
-    select(true)(23) should be (res0)
+    select(true)(23) should be(res0)
 
     //select(true)("foo")
     //error: type mismatch;
@@ -76,7 +75,7 @@ object SingletonExercises extends FlatSpec with Matchers with exercise.Section {
     //found   : Int(23)
     //required: String
 
-    select(false)("foo") should be (res1)
+    select(false)("foo") should be(res1)
   }
 
 }

--- a/site/content/src/main/scala/shapeless/SingletonTypedSymbolsExercises.scala
+++ b/site/content/src/main/scala/shapeless/SingletonTypedSymbolsExercises.scala
@@ -4,13 +4,12 @@ import org.scalatest._
 import shapeless._
 import ops.hlist._
 
-/** 
-  * Scala's Symbol type, despite having its own syntax and being isomorphic to the String type, 
-  * isn't equipped with useful singleton-typed literals. 
-  * An encoding of singleton types for Symbol literals has proven to be valuable (see below), 
+/** Scala's Symbol type, despite having its own syntax and being isomorphic to the String type,
+  * isn't equipped with useful singleton-typed literals.
+  * An encoding of singleton types for Symbol literals has proven to be valuable (see below),
   * and is represented by tagging the non-singleton type with the singleton type of the corresponding String literal
-  * 
-  * @param name singleton_typed_symbols  
+  *
+  * @param name singleton_typed_symbols
   */
 object SingletonTypedSymbolsExercises extends FlatSpec with Matchers with exercise.Section {
 
@@ -22,5 +21,4 @@ object SingletonTypedSymbolsExercises extends FlatSpec with Matchers with exerci
    */
 
 }
-
 

--- a/site/content/src/main/scala/shapeless/TuplesExercises.scala
+++ b/site/content/src/main/scala/shapeless/TuplesExercises.scala
@@ -3,12 +3,11 @@ package shapelessex
 import org.scalatest._
 import shapeless._
 
-/** 
-  * shapeless allows standard Scala tuples to be manipulated in exactly the same ways as HLists
+/** shapeless allows standard Scala tuples to be manipulated in exactly the same ways as HLists
   * {{{
   * import syntax.std.tuple._
   * }}}
-  * 
+  *
   * @param name tuples
   */
 object TuplesExercises extends FlatSpec with Matchers with exercise.Section {
@@ -17,53 +16,53 @@ object TuplesExercises extends FlatSpec with Matchers with exercise.Section {
 
   /** head
     */
-  def head(res0 : Int) = {
-    (23, "foo", true).head should be (res0)
+  def head(res0: Int) = {
+    (23, "foo", true).head should be(res0)
   }
 
   /** tail
     */
-  def tail(res0 : (String, Boolean)) = {
-    (23, "foo", true).tail should be (res0)
+  def tail(res0: (String, Boolean)) = {
+    (23, "foo", true).tail should be(res0)
   }
 
   /** drop
     */
-  def drop(res0 : Any) = {
-    (23, "foo", true).drop(2) should be (res0)
+  def drop(res0: Any) = {
+    (23, "foo", true).drop(2) should be(res0)
   }
 
   /** take
     */
-  def take(res0 : (Int, String)) = {
-    (23, "foo", true).take(2) should be (res0)
+  def take(res0: (Int, String)) = {
+    (23, "foo", true).take(2) should be(res0)
   }
 
   /** split
     */
-  def split(res0 : ((Int), (String, Boolean))) = {
-    (23, "foo", true).split(1) should be (res0)
+  def split(res0: ((Int), (String, Boolean))) = {
+    (23, "foo", true).split(1) should be(res0)
   }
 
   /** prepend
     */
-  def prepend(res0 : (Int, String, Boolean)) = {
+  def prepend(res0: (Int, String, Boolean)) = {
     val l = 23 +: ("foo", true)
-    l should be (res0)
+    l should be(res0)
   }
 
   /** append
     */
-  def append(res0 : (Int, String, Boolean)) = {
+  def append(res0: (Int, String, Boolean)) = {
     val l = (23, "foo") :+ true
-    l should be (res0)
+    l should be(res0)
   }
 
   /** concatenate
     */
-  def concatenate(res0 : (Int, String, Boolean, Double)) = {
+  def concatenate(res0: (Int, String, Boolean, Double)) = {
     val l = (23, "foo") ++ (true, 2.0)
-    l should be (res0)
+    l should be(res0)
   }
 
   import poly._
@@ -72,78 +71,77 @@ object TuplesExercises extends FlatSpec with Matchers with exercise.Section {
     def apply[T](t: T) = Option(t)
   }
 
-  /** map 
+  /** map
     * {{{
     * import poly._
-    * 
+    *
     * object option extends (Id ~> Option) {
-    *  def apply[T](t: T) = Option(t)
+    * def apply[T](t: T) = Option(t)
     * }
     * }}}
     */
-  def map(res0 : (Option[Int], Option[String], Option[Boolean])) = {
+  def map(res0: (Option[Int], Option[String], Option[Boolean])) = {
     val l = (23, "foo", true) map option
-    l should be (res0)
+    l should be(res0)
   }
 
-  /** flatMap 
+  /** flatMap
     */
-  def flatMap(res0 : (Int, String, Boolean, Double)) = {
+  def flatMap(res0: (Int, String, Boolean, Double)) = {
     val l = ((23, "foo"), (), (true, 2.0)) flatMap identity
-    l should be (res0)
+    l should be(res0)
   }
 
   object sizeOf extends Poly1 {
-  implicit def caseInt = at[Int](x => 1)
-  implicit def caseString = at[String](_.length)
-  implicit def caseTuple[T, U]
-    (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
-      at[(T, U)](t => sizeOf(t._1)+sizeOf(t._2))
-}
+    implicit def caseInt = at[Int](x ⇒ 1)
+    implicit def caseString = at[String](_.length)
+    implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
+      at[(T, U)](t ⇒ sizeOf(t._1) + sizeOf(t._2))
+  }
 
   object addSize extends Poly2 {
     implicit def default[T](implicit st: sizeOf.Case.Aux[T, Int]) =
-      at[Int, T]{ (acc, t) => acc+sizeOf(t) }
+      at[Int, T] { (acc, t) ⇒ acc + sizeOf(t) }
   }
 
   /** fold
-    *  {{{
+    * {{{
     * object size extends Poly1 {
-    *   implicit def caseInt = at[Int](x => 1)
-    *   implicit def caseString = at[String](_.length)
-    *   implicit def caseTuple[T, U]
-    *     (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
-    *       at[(T, U)](t => size(t._1)+size(t._2))
+    *  implicit def caseInt = at[Int](x => 1)
+    *  implicit def caseString = at[String](_.length)
+    *  implicit def caseTuple[T, U]
+    *    (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
+    *      at[(T, U)](t => size(t._1)+size(t._2))
     * }
-    * 
+    *
     * object addSize extends Poly2 {
-    *  implicit def default[T](implicit st: size.Case.Aux[T, Int]) =
-    *   at[Int, T]{ (acc, t) => acc+size(t) }
+    * implicit def default[T](implicit st: size.Case.Aux[T, Int]) =
+    *  at[Int, T]{ (acc, t) => acc+size(t) }
     * }
     * }}}
     */
-  def fold(res0 : Int) = {
-    (23, "foo", (13, "wibble")).foldLeft(0)(addSize) should be (res0)
+  def fold(res0: Int) = {
+    (23, "foo", (13, "wibble")).foldLeft(0)(addSize) should be(res0)
   }
 
   /** conversion to `HList`
     */
-  def toHList(res0 : Int :: String :: Boolean :: HNil) = {
-    (23, "foo", true).productElements should be (res0)
+  def toHList(res0: Int :: String :: Boolean :: HNil) = {
+    (23, "foo", true).productElements should be(res0)
   }
 
   /** conversion to `List`
     */
-  def toList(res0 : List[Any]) = {
-    (23, "foo", true).toList should be (res0)
+  def toList(res0: List[Any]) = {
+    (23, "foo", true).toList should be(res0)
   }
 
   /** zipper
     */
-  def zipper(res0 : (Int, (String, Boolean), Double)) = {
+  def zipper(res0: (Int, (String, Boolean), Double)) = {
     import syntax.zipper._
     val l = (23, ("foo", true), 2.0).toZipper.right.down.put("bar").root.reify
-    l should be (res0)
+    l should be(res0)
   }
 
 }

--- a/site/content/src/main/scala/stdlib/Asserts.scala
+++ b/site/content/src/main/scala/stdlib/Asserts.scala
@@ -2,17 +2,15 @@ package stdlib
 
 import org.scalatest._
 
-/**
-  * @param name asserts
+/** @param name asserts
   */
 object Asserts extends FlatSpec with Matchers with exercise.Section {
 
-
   /** ScalaTest makes three assertions available by default in any style trait. You can use:
     *
-    *    - `assert` for general assertions;
-    *    - `assertResult` to differentiate expected from actual values;
-    *    - `intercept` to ensure a bit of code throws an expected exception.
+    *   - `assert` for general assertions;
+    *   - `assertResult` to differentiate expected from actual values;
+    *   - `intercept` to ensure a bit of code throws an expected exception.
     *
     * In any Scala program, you can write assertions by invoking `assert` and passing in a `Boolean` expression:
     *

--- a/site/content/src/main/scala/stdlib/ByNameParameter.scala
+++ b/site/content/src/main/scala/stdlib/ByNameParameter.scala
@@ -2,24 +2,22 @@ package stdlib
 
 import org.scalatest._
 
-/**
-  * @param name byname_parameter
+/** @param name byname_parameter
   */
 object ByNameParameter extends FlatSpec with Matchers with exercise.Section {
-
 
   /** `() => Int` is a Function type that takes a `Unit` type. `Unit` is known as `void` to a Java programmer. The function returns an `Int`. You can place this as a method parameter so that you can you use it as a block, but still it doesn't look quite right.
     */
   def takesUnitByNameParameter(res0: Either[Throwable, Int]) {
-    def calc(x: () => Int): Either[Throwable, Int] = {
+    def calc(x: () ⇒ Int): Either[Throwable, Int] = {
       try {
         Right(x()) //An explicit call the x function
       } catch {
-        case b: Throwable => Left(b)
+        case b: Throwable ⇒ Left(b)
       }
     }
 
-    val y = calc { () => //Having explicitly declaring that Unit is a parameter with ()
+    val y = calc { () ⇒ //Having explicitly declaring that Unit is a parameter with ()
       14 + 15
     }
 
@@ -29,12 +27,12 @@ object ByNameParameter extends FlatSpec with Matchers with exercise.Section {
   /** A by-name parameter does the same thing as the previous koan but there is no need to explicitly handle `Unit` or `()`. This is used extensively in scala to create blocks.
     */
   def byNameParameter(res0: Either[Throwable, Int]) {
-    def calc(x: => Int): Either[Throwable, Int] = {
+    def calc(x: ⇒ Int): Either[Throwable, Int] = {
       //x is a call by name parameter
       try {
         Right(x)
       } catch {
-        case b: Throwable => Left(b)
+        case b: Throwable ⇒ Left(b)
       }
     }
 
@@ -52,7 +50,7 @@ object ByNameParameter extends FlatSpec with Matchers with exercise.Section {
     */
   def withApplyByNameParameter(res0: String) {
     object PigLatinizer {
-      def apply(x: => String) = x.tail + x.head + "ay"
+      def apply(x: ⇒ String) = x.tail + x.head + "ay"
     }
 
     val result = PigLatinizer {

--- a/site/content/src/main/scala/stdlib/CaseClasses.scala
+++ b/site/content/src/main/scala/stdlib/CaseClasses.scala
@@ -2,11 +2,9 @@ package stdlib
 
 import org.scalatest._
 
-/**
-  * @param name case_classes
+/** @param name case_classes
   */
 object CaseClasses extends FlatSpec with Matchers with exercise.Section {
-
 
   /** Scala supports the notion of _case classes_. Case classes are regular classes which export their constructor parameters and which provide a recursive decomposition mechanism via pattern matching.
     *
@@ -55,31 +53,31 @@ object CaseClasses extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object TermTest extends Application {
-    *   def printTerm(term: Term) {
-    *     term match {
-    *       case Var(n) =>
-    *         print(n)
-    *       case Fun(x, b) =>
-    *         print("^" + x + ".")
-    *         printTerm(b)
-    *       case App(f, v) =>
-    *         Console.print("(")
-    *         printTerm(f)
-    *         print(" ")
-    *         printTerm(v)
-    *         print(")")
-    *     }
-    *   }
-    *   def isIdentityFun(term: Term): Boolean = term match {
-    *     case Fun(x, Var(y)) if x == y => true
-    *     case _ => false
-    *   }
-    *   val id = Fun("x", Var("x"))
-    *   val t = Fun("x", Fun("y", App(Var("x"), Var("y"))))
-    *   printTerm(t)
-    *   println
-    *   println(isIdentityFun(id))
-    *   println(isIdentityFun(t))
+    *  def printTerm(term: Term) {
+    *    term match {
+    *      case Var(n) =>
+    *        print(n)
+    *      case Fun(x, b) =>
+    *        print("^" + x + ".")
+    *        printTerm(b)
+    *      case App(f, v) =>
+    *        Console.print("(")
+    *        printTerm(f)
+    *        print(" ")
+    *        printTerm(v)
+    *        print(")")
+    *    }
+    *  }
+    *  def isIdentityFun(term: Term): Boolean = term match {
+    *    case Fun(x, Var(y)) if x == y => true
+    *    case _ => false
+    *  }
+    *  val id = Fun("x", Var("x"))
+    *  val t = Fun("x", Fun("y", App(Var("x"), Var("y"))))
+    *  printTerm(t)
+    *  println
+    *  println(isIdentityFun(id))
+    *  println(isIdentityFun(t))
     * }
     * }}}
     *
@@ -229,7 +227,6 @@ object CaseClasses extends FlatSpec with Matchers with exercise.Section {
     val indy = PersonCC("Indiana", "Jones")
 
     indy.isInstanceOf[Serializable] should be(res0)
-
 
     class Person(firstName: String, lastName: String)
     val junior = new Person("Indiana", "Jones")

--- a/site/content/src/main/scala/stdlib/Classes.scala
+++ b/site/content/src/main/scala/stdlib/Classes.scala
@@ -2,24 +2,22 @@ package stdlib
 
 import org.scalatest._
 
-/**
-  * @param name classes
+/** @param name classes
   */
 object Classes extends FlatSpec with Matchers with exercise.Section {
-
 
   /** Classes in Scala are static templates that can be instantiated into many objects at runtime.
     * Here is a class definition which defines a class Point:
     *
     * {{{
     * class Point(xc: Int, yc: Int) {
-    *   var x: Int = xc
-    *   var y: Int = yc
-    *   def move(dx: Int, dy: Int) {
-    *     x = x + dx
-    *     y = y + dy
-    *   }
-    *   override def toString(): String = "(" + x + ", " + y + ")";
+    *  var x: Int = xc
+    *  var y: Int = yc
+    *  def move(dx: Int, dy: Int) {
+    *    x = x + dx
+    *    y = y + dy
+    *  }
+    *  override def toString(): String = "(" + x + ", " + y + ")";
     * }
     * }}}
     * The class defines two variables `x` and `y` and two methods: `move` and `toString`.
@@ -32,12 +30,12 @@ object Classes extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object Classes {
-    *   def main(args: Array[String]) {
-    *     val pt = new Point(1, 2)
-    *     println(pt)
-    *     pt.move(10, 10)
-    *     println(pt)
-    *   }
+    *  def main(args: Array[String]) {
+    *    val pt = new Point(1, 2)
+    *    println(pt)
+    *    pt.move(10, 10)
+    *    println(pt)
+    *  }
     * }
     * }}}
     *
@@ -76,7 +74,8 @@ object Classes extends FlatSpec with Matchers with exercise.Section {
       * class ClassWithPrivateFields(name: String)
       * val aClass = new ClassWithPrivateFields("name")
       * }}}
-      * NOTE: `aClass.name` is not accessible */
+      * NOTE: `aClass.name` is not accessible
+      */
   }
 
 }

--- a/site/content/src/main/scala/stdlib/Constructors.scala
+++ b/site/content/src/main/scala/stdlib/Constructors.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Constructors extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Primary Constructor
     *
     * In Java we have a no-args default constructor which is provided for every class which doesn't provide its own constructor methods. On a similar lines Primary Constructor in Scala is the kind-of default constructor in the way every class in Scala would have a Primary Constructor.
@@ -16,7 +15,7 @@ object Constructors extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class Employee {
-    *   var age:Int = 20
+    *  var age:Int = 20
     * }
     * }}}
     *
@@ -27,9 +26,9 @@ object Constructors extends FlatSpec with Matchers with exercise.Section {
     * class Employee(val firstName:String,
     * val lastName:String) {
     *
-    *   override def toString():String = {
-    *     "First Name: " + firstName + " Last Name: " + lastName
-    *   }
+    *  override def toString():String = {
+    *    "First Name: " + firstName + " Last Name: " + lastName
+    *  }
     * }
     * }}}
     *
@@ -41,17 +40,17 @@ object Constructors extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class Employee(val firstName:String, val lastName:String) {
-    *   var age:Int = 0
+    *  var age:Int = 0
     *
-    *   //Auxiliary Constructor
-    *   def this(firstName:String, lastName: String, age:Int) {
-    *     this(firstName,lastName)
-    *     this.age = age
-    *   }
+    *  //Auxiliary Constructor
+    *  def this(firstName:String, lastName: String, age:Int) {
+    *    this(firstName,lastName)
+    *    this.age = age
+    *  }
     *
-    *   override def toString():String = {
-    *     "First Name: " + firstName + " Last Name: " + lastName
-    *   }
+    *  override def toString():String = {
+    *    "First Name: " + firstName + " Last Name: " + lastName
+    *  }
     * }
     * }}}
     *
@@ -60,23 +59,23 @@ object Constructors extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class Employee(val firstName:String, val lastName:String) {
-    *   var age:Int = 0
-    *   var city:String = _
+    *  var age:Int = 0
+    *  var city:String = _
     *
-    *   def this(firstName:String, lastName: String,
-    *   city:String, age:Int) {
-    *     this(firstName, lastName, city)
-    *     this.age = age
-    *   }
+    *  def this(firstName:String, lastName: String,
+    *  city:String, age:Int) {
+    *    this(firstName, lastName, city)
+    *    this.age = age
+    *  }
     *
-    *   def this(firstName:String, lastName: String, city:String) {
-    *     this(firstName,lastName)
-    *     this.city = city
-    *   }
+    *  def this(firstName:String, lastName: String, city:String) {
+    *    this(firstName,lastName)
+    *    this.city = city
+    *  }
     *
-    *   override def toString():String = {
-    *     "First Name: " + firstName + " Last Name: " + lastName
-    *   }
+    *  override def toString():String = {
+    *    "First Name: " + firstName + " Last Name: " + lastName
+    *  }
     * }
     * }}}
     *

--- a/site/content/src/main/scala/stdlib/EmptyValues.scala
+++ b/site/content/src/main/scala/stdlib/EmptyValues.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object EmptyValues extends FlatSpec with Matchers with exercise.Section {
 
-
   /** ==null==
     *
     * Scala's `null` is the same as in Java. Any reference type can be `null`, like Strings, Objects, or your own classes. Also just like Java, value types like Ints can't be `null`.

--- a/site/content/src/main/scala/stdlib/Enumerations.scala
+++ b/site/content/src/main/scala/stdlib/Enumerations.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Enumerations extends FlatSpec with Matchers with exercise.Section {
 
-
   /** To create an enumeration, create an object that extends the abstract class `Enumeration`, and set a `val` variable to the method `Value`.  This is a trick to give values to each `val`.
     *
     * `Value` assigns a numerical value to fields:

--- a/site/content/src/main/scala/stdlib/Extractors.scala
+++ b/site/content/src/main/scala/stdlib/Extractors.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Extractors extends FlatSpec with Matchers with exercise.Section {
 
-
   /** In Scala, patterns can be defined independently of case classes. To this end, a method named `unapply` is defined to yield a so-called extractor.
     *
     * For instance, the following code defines an extractor object `Twice`.
@@ -53,8 +52,8 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
 
     val rob = new Employee("Robin", "Williams")
     val result = rob match {
-      case Employee("Robin", _) => "Where's Batman?"
-      case _ => "No Batman Joke For You"
+      case Employee("Robin", _) ⇒ "Where's Batman?"
+      case _                    ⇒ "No Batman Joke For You"
     }
 
     result should be(res0)
@@ -87,8 +86,8 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
     }
 
     val x = new Car("Chevy", "Camaro", 1978, 120) match {
-      case ChopShop(s, t, u, v) => (s, t)
-      case _ => ("Ford", "Edsel")
+      case ChopShop(s, t, u, v) ⇒ (s, t)
+      case _                    ⇒ ("Ford", "Edsel")
     }
 
     x._1 should be(res0)
@@ -104,10 +103,9 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
       def unapply(x: Car) = Some(x.make, x.model, x.year, x.topSpeed)
     }
 
-
     val x = new Car("Chevy", "Camaro", 1978, 120) match {
-      case ChopShop(s, t, _, _) => (s, t)
-      case _ => ("Ford", "Edsel")
+      case ChopShop(s, t, _, _) ⇒ (s, t)
+      case _                    ⇒ ("Ford", "Edsel")
     }
 
     x._1 should be(res0)
@@ -127,8 +125,8 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
     }
 
     val result = new Employee("Kurt", None, "Vonnegut") match {
-      case Tokenizer(c, d) => "c: %s, d: %s".format(c, d)
-      case _ => "Not found"
+      case Tokenizer(c, d) ⇒ "c: %s, d: %s".format(c, d)
+      case _               ⇒ "Not found"
     }
 
     result should be(res0)
@@ -144,8 +142,8 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
     val camaro = new Car("Chevy", "Camaro", 1978, 122)
 
     val result = camaro match {
-      case camaro(make, model) => "make: %s, model: %s".format(make, model)
-      case _ => "unknown"
+      case camaro(make, model) ⇒ "make: %s, model: %s".format(make, model)
+      case _                   ⇒ "unknown"
     }
 
     result should be(res0)
@@ -154,9 +152,11 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
   /** What is typical is to create a custom extractor in the companion object of the class. In this exercise, we use it as an assignment:
     */
   def asAssignmentExtractors(res0: String, res1: Option[String], res2: String) {
-    class Employee(val firstName: String,
-        val middleName: Option[String],
-        val lastName: String)
+    class Employee(
+      val firstName:  String,
+      val middleName: Option[String],
+      val lastName:   String
+    )
 
     object Employee {
       //factory methods, extractors, apply
@@ -177,9 +177,11 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
   /** In this exercise we use the unapply for pattern matching employee objects
     */
   def unapplyForPatternMatchingExtractors(res0: String) {
-    class Employee(val firstName: String,
-        val middleName: Option[String],
-        val lastName: String)
+    class Employee(
+      val firstName:  String,
+      val middleName: Option[String],
+      val lastName:   String
+    )
 
     object Employee {
       //factory methods, extractors, apply
@@ -191,9 +193,9 @@ object Extractors extends FlatSpec with Matchers with exercise.Section {
     val singri = new Employee("Singri", None, "Keerthi")
 
     val result = singri match {
-      case Employee("Singri", None, x) => "Yay, Singri %s! with no middle name!".format(x)
-      case Employee("Singri", Some(x), _) => "Yay, Singri with a middle name of %s".format(x)
-      case _ => "I don't care, going on break"
+      case Employee("Singri", None, x)    ⇒ "Yay, Singri %s! with no middle name!".format(x)
+      case Employee("Singri", Some(x), _) ⇒ "Yay, Singri with a middle name of %s".format(x)
+      case _                              ⇒ "I don't care, going on break"
     }
 
     result should be(res0)

--- a/site/content/src/main/scala/stdlib/ForExpressions.scala
+++ b/site/content/src/main/scala/stdlib/ForExpressions.scala
@@ -7,13 +7,12 @@ import org.scalatest._
   */
 object ForExpressions extends FlatSpec with Matchers with exercise.Section {
 
-
   /** For loops can be simple:
     */
   def forLoopsForExpressions(res0: Int) {
     val someNumbers = Range(0, 10)
     var sum = 0
-    for (i <- someNumbers)
+    for (i ← someNumbers)
       sum += i
 
     sum should equal(res0)
@@ -25,7 +24,7 @@ object ForExpressions extends FlatSpec with Matchers with exercise.Section {
     val someNumbers = Range(0, 10)
     var sum = 0
 
-    for (i <- someNumbers)
+    for (i ← someNumbers)
       if (i % 2 == 0) sum += i
 
     sum should equal(res0)
@@ -38,8 +37,9 @@ object ForExpressions extends FlatSpec with Matchers with exercise.Section {
     val xValues = Range(1, 5)
     val yValues = Range(1, 3)
     val coordinates = for {
-      x <- xValues
-      y <- yValues} yield (x, y)
+      x ← xValues
+      y ← yValues
+    } yield (x, y)
     coordinates(4) should be(res0, res1)
   }
 
@@ -49,15 +49,15 @@ object ForExpressions extends FlatSpec with Matchers with exercise.Section {
     val nums = List(List(1), List(2), List(3), List(4), List(5))
 
     val result = for {
-      numList <- nums
-      num <- numList
+      numList ← nums
+      num ← numList
       if (num % 2 == 0)
     } yield (num)
 
     result should be(res0)
 
     // Which is the same as
-    nums.flatMap(numList => numList).filter(_ % 2 == 0) should be(result)
+    nums.flatMap(numList ⇒ numList).filter(_ % 2 == 0) should be(result)
 
     // or the same as
     nums.flatten.filter(_ % 2 == 0) should be(result)

--- a/site/content/src/main/scala/stdlib/Formatting.scala
+++ b/site/content/src/main/scala/stdlib/Formatting.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Formatting extends FlatSpec with Matchers with exercise.Section {
 
-
   /** String can be placed in format:
     */
   def placedInFormatFormatting(res0: String) {
@@ -20,7 +19,6 @@ object Formatting extends FlatSpec with Matchers with exercise.Section {
   def characterFormatting(res0: String, res1: String) {
     val a = 'a'
     val b = 'B'
-
 
     //format(a) is a string format, meaning the "%c".format(x)
     //will return the string representation of the char.
@@ -36,7 +34,6 @@ object Formatting extends FlatSpec with Matchers with exercise.Section {
     val d = '\141' //octal for a
     val e = '\"'
     val f = '\\'
-
 
     "%c".format(c) should be(res0)
     "%c".format(d) should be(res1)

--- a/site/content/src/main/scala/stdlib/HigherOrderFunctions.scala
+++ b/site/content/src/main/scala/stdlib/HigherOrderFunctions.scala
@@ -7,15 +7,14 @@ import org.scalatest._
   */
 object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Meet lambda. Scala provides a relatively lightweight syntax for defining anonymous functions. Anonymous functions in source code are called function literals and at run time, function literals are instantiated into objects called function values.
     *
     * Scala supports first-class functions, which means you can express functions in function literal syntax, i.e.,` (x: Int) => x + 1`, and that functions can be represented by objects, which are called function values.
     */
   def meetLambdaHigherOrderFunctions(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int, res5: Int) {
-    def lambda = { x: Int => x + 1 }
-    def lambda2 = (x: Int) => x + 1
-    val lambda3 = (x: Int) => x + 1
+    def lambda = { x: Int ⇒ x + 1 }
+    def lambda2 = (x: Int) ⇒ x + 1
+    val lambda3 = (x: Int) ⇒ x + 1
 
     val lambda4 = new Function1[Int, Int] {
       def apply(v1: Int): Int = v1 + 1
@@ -42,7 +41,7 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
   /** An anonymous function can also take on a different look by taking out the brackets
     */
   def differentLookHigherOrderFunctions(res0: Int) {
-    def lambda = (x: Int) => x + 1
+    def lambda = (x: Int) ⇒ x + 1
     def result = lambda(5)
     result should be(res0)
   }
@@ -57,7 +56,7 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
     var incrementer = 1
 
     def closure = {
-      x: Int => x + incrementer
+      x: Int ⇒ x + incrementer
     }
 
     val result1 = closure(10)
@@ -72,10 +71,10 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
   /** We can take that closure and throw into a method and it will still hold the environment
     */
   def holdEnvironmentHigherOrderFunctions(res0: Int, res1: Int) {
-    def summation(x: Int, y: Int => Int) = y(x)
+    def summation(x: Int, y: Int ⇒ Int) = y(x)
 
     var incrementer = 3
-    def closure = (x: Int) => x + incrementer
+    def closure = (x: Int) ⇒ x + incrementer
 
     val result = summation(10, closure)
     result should be(res0)
@@ -94,7 +93,7 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
       }
     }
     addWithoutSyntaxSugar(1).
-        isInstanceOf[Function1[Int, Int]] should be(res0)
+      isInstanceOf[Function1[Int, Int]] should be(res0)
 
     addWithoutSyntaxSugar(2)(3) should be(res1)
 
@@ -105,7 +104,7 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
   /** Function returning another function using an anonymous function:
     */
   def returningAnonymousFunctionHigherOrderFunctions(res0: Boolean, res1: Int, res2: Int) {
-    def addWithSyntaxSugar(x: Int) = (y: Int) => x + y
+    def addWithSyntaxSugar(x: Int) = (y: Int) ⇒ x + y
 
     addWithSyntaxSugar(1).isInstanceOf[Function1[Int, Int]] should be(res0)
     addWithSyntaxSugar(2)(3) should be(res1)
@@ -117,7 +116,7 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
   /** `isInstanceOf` is the same as `instanceof` in java, but in this case the parameter types can be *blanked out* using existential types with a single underline, since parameter type are unknown at runtime.
     */
   def isInstanceOfMethodHigherOrderFunctions(res0: Boolean) {
-    def addWithSyntaxSugar(x: Int) = (y: Int) => x + y
+    def addWithSyntaxSugar(x: Int) = (y: Int) ⇒ x + y
 
     addWithSyntaxSugar(1).isInstanceOf[Function1[_, _]] should be(res0)
   }
@@ -131,14 +130,14 @@ object HigherOrderFunctions extends FlatSpec with Matchers with exercise.Section
       _.toUpperCase
     }
 
-    def makeWhatEverYouLike(xs: List[String], sideEffect: String => String) = {
+    def makeWhatEverYouLike(xs: List[String], sideEffect: String ⇒ String) = {
       xs map sideEffect
     }
 
     makeUpper(List("abc", "xyz", "123")) should be(res0)
 
     makeWhatEverYouLike(List("ABC", "XYZ", "123"), {
-      x => x.toLowerCase
+      x ⇒ x.toLowerCase
     }) should be(res1)
 
     //using it inline

--- a/site/content/src/main/scala/stdlib/Implicits.scala
+++ b/site/content/src/main/scala/stdlib/Implicits.scala
@@ -8,32 +8,31 @@ import scala.language.implicitConversions
   */
 object Implicits extends FlatSpec with Matchers with exercise.Section {
 
-
   /** The actual arguments that are eligible to be passed to an implicit parameter fall into two categories: * First, eligible are all identifiers x that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter. * Second, eligible are also all members of companion modules of the implicit parameter's type that are labeled implicit.
     *
     * In the following example we define a method sum which computes the sum of a list of elements using the monoid's add and unit operations. Please note that implicit values can not be top-level, they have to be members of a template.
     *
     * {{{
     * abstract class SemiGroup[A] {
-    *   def add(x: A, y: A): A
+    *  def add(x: A, y: A): A
     * }
     * abstract class Monoid[A] extends SemiGroup[A] {
-    *   def unit: A
+    *  def unit: A
     * }
     * object ImplicitTest extends App {
-    *   implicit object StringMonoid extends Monoid[String] {
-    *     def add(x: String, y: String): String = x concat y
-    *     def unit: String = ""
-    *   }
-    *   implicit object IntMonoid extends Monoid[Int] {
-    *     def add(x: Int, y: Int): Int = x + y
-    *     def unit: Int = 0
-    *   }
-    *   def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
-    *     if (xs.isEmpty) m.unit
-    *     else m.add(xs.head, sum(xs.tail))
-    *   println(sum(List(1, 2, 3)))
-    *   println(sum(List("a", "b", "c")))
+    *  implicit object StringMonoid extends Monoid[String] {
+    *    def add(x: String, y: String): String = x concat y
+    *    def unit: String = ""
+    *  }
+    *  implicit object IntMonoid extends Monoid[Int] {
+    *    def add(x: Int, y: Int): Int = x + y
+    *    def unit: Int = 0
+    *  }
+    *  def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
+    *    if (xs.isEmpty) m.unit
+    *    else m.add(xs.head, sum(xs.tail))
+    *  println(sum(List(1, 2, 3)))
+    *  println(sum(List("a", "b", "c")))
     * }
     * }}}
     *
@@ -88,7 +87,6 @@ object Implicits extends FlatSpec with Matchers with exercise.Section {
     implicit def Int2BigIntegerConvert(value: Int): BigInteger = new BigInteger(value.toString)
 
     def add(a: BigInteger, b: BigInteger) = a.add(b)
-
 
     add(Int2BigIntegerConvert(3), Int2BigIntegerConvert(6)) == Int2BigIntegerConvert(9) should be(res0)
 

--- a/site/content/src/main/scala/stdlib/InfixPrefixandPostfixOperators.scala
+++ b/site/content/src/main/scala/stdlib/InfixPrefixandPostfixOperators.scala
@@ -8,7 +8,6 @@ import scala.language.postfixOps
   */
 object InfixPrefixandPostfixOperators extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Any method which takes a single parameter can be used as an infix operator: `a.m(b)` can be written `a m b`.
     */
   def singleParameterInfixPrefixandPostfixOperators(res0: Int, res1: Int) {
@@ -34,9 +33,9 @@ object InfixPrefixandPostfixOperators extends FlatSpec with Matchers with exerci
     * For instance `a.##(b)` can be written `a ## b` and `a.!` can be written `a!`
     *
     * **Postfix operators** have lower precedence than **infix operators**, so:
-    *    - `foo bar baz` means `foo.bar(baz)`.
-    *    - `foo bar baz bam` means `(foo.bar(baz)).bam`
-    *    - `foo bar baz bam bim` means `(foo.bar(baz)).bam(bim)`.
+    *   - `foo bar baz` means `foo.bar(baz)`.
+    *   - `foo bar baz bam` means `(foo.bar(baz)).bam`
+    *   - `foo bar baz bam bim` means `(foo.bar(baz)).bam(bim)`.
     */
   def postfixOperatorInfixPrefixandPostfixOperators(res0: String) {
     val g: Int = 31

--- a/site/content/src/main/scala/stdlib/InfixTypes.scala
+++ b/site/content/src/main/scala/stdlib/InfixTypes.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object InfixTypes extends FlatSpec with Matchers with exercise.Section {
 
-
   /** An infix type `T1 op T2` consists of an infix operator `op` which gets applied to two
     * type operands `T1` and `T2`. The type is equivalent to the type application `op[T1,T2]`.
     *

--- a/site/content/src/main/scala/stdlib/Iterables.scala
+++ b/site/content/src/main/scala/stdlib/Iterables.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Iterables extends FlatSpec with Matchers with exercise.Section {
 
-
   /** The next trait from the top in the collections hierarchy is `Iterable`. All methods in this trait are defined in terms of an abstract method, `iterator`, which yields the collection's elements one by one. The `foreach` method from trait `Traversable` is implemented in `Iterable` in terms of `iterator`. Here is the actual implementation:
     *
     *
@@ -54,7 +53,7 @@ object Iterables extends FlatSpec with Matchers with exercise.Section {
     */
   def slidingWindowIterables(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int, res5: Int, res6: Int, res7: Int, res8: Int) {
     val list = List(3, 5, 9, 11, 15, 19, 21, 24, 32)
-    val it = list sliding(3, 3)
+    val it = list sliding (3, 3)
     it.next() should be(List(res0, res1, res2))
     it.next() should be(List(res3, res4, res5))
     it.next() should be(List(res6, res7, res8))
@@ -102,12 +101,11 @@ object Iterables extends FlatSpec with Matchers with exercise.Section {
   def zipAllIterables(res0: Int, res1: String, res2: Int, res3: String, res4: Int, res5: Int, res6: String, res7: Int, res8: String, res9: String) {
     val xs = List(3, 5, 9)
     val ys = List("Bob", "Ann")
-    (xs zipAll(ys, -1, "?")) should be(List((res0, res1), (res2, res3), (res4, "?")))
+    (xs zipAll (ys, -1, "?")) should be(List((res0, res1), (res2, res3), (res4, "?")))
 
     val xt = List(3, 5)
     val yt = List("Bob", "Ann", "Stella")
-    (xt zipAll(yt, -1, "?")) should be(List((res5, res6), (res7, res8), (-1, res9)))
-
+    (xt zipAll (yt, -1, "?")) should be(List((res5, res6), (res7, res8), (-1, res9)))
 
   }
 

--- a/site/content/src/main/scala/stdlib/Lists.scala
+++ b/site/content/src/main/scala/stdlib/Lists.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Lists extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Scala Lists are quite similar to arrays which means, all the elements of a list have the same type but there are two important differences. First, lists are immutable, which means elements of a list cannot be changed by assignment. Second, lists represent a linked list whereas arrays are flat. The type of a list that has elements of type `T` is written as `List[T]`.
     *
     * `eq` tests identity (same object)
@@ -74,7 +73,7 @@ object Lists extends FlatSpec with Matchers with exercise.Section {
     */
   def areImmutableLists(res0: Int, res1: Int, res2: Int, res3: Int) {
     val a = List(1, 3, 5, 7, 9)
-    val b = a.filterNot(v => v == 5) // remove where value is 5
+    val b = a.filterNot(v ⇒ v == 5) // remove where value is 5
 
     a should equal(List(1, 3, 5, 7, 9))
     b should equal(List(res0, res1, res2, res3))
@@ -92,10 +91,10 @@ object Lists extends FlatSpec with Matchers with exercise.Section {
     a.reverse should equal(res1)
 
     // map a function to double the numbers over the list
-    a.map { v => v * 2 } should equal(res2)
+    a.map { v ⇒ v * 2 } should equal(res2)
 
     // filter any values divisible by 3 in the list
-    a.filter { v => v % 3 == 0 } should equal(res3)
+    a.filter { v ⇒ v % 3 == 0 } should equal(res3)
   }
 
   /** Functions over lists can use _ as shorthand

--- a/site/content/src/main/scala/stdlib/LiteralBooleans.scala
+++ b/site/content/src/main/scala/stdlib/LiteralBooleans.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object LiteralBooleans extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Boolean literals are either true or false, using the true or false keyword
     */
   def literalBooleanLiteralBooleans(res0: Boolean, res1: Boolean, res2: Boolean, res3: Boolean, res4: Boolean, res5: Boolean) {

--- a/site/content/src/main/scala/stdlib/LiteralNumbers.scala
+++ b/site/content/src/main/scala/stdlib/LiteralNumbers.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object LiteralNumbers extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Integer Literals are 32-bit and can be created from decimal, hexadecimal:
     */
   def integerLiteralsLiteralNumbers(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int, res5: Int, res6: Int) {

--- a/site/content/src/main/scala/stdlib/LiteralStrings.scala
+++ b/site/content/src/main/scala/stdlib/LiteralStrings.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object LiteralStrings extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Character Literals are quoted with single quotes:
     */
   def characterLiteralsLiteralStrings(res0: String, res1: String) {

--- a/site/content/src/main/scala/stdlib/Maps.scala
+++ b/site/content/src/main/scala/stdlib/Maps.scala
@@ -11,38 +11,38 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
     *
     * The fundamental operations on maps are similar to those on sets. They are summarized in the following table and fall into the following categories:
     *
-    *    - Lookup operations `apply`, `get`, `getOrElse`, `contains`, and `isDefinedAt`. These turn maps into partial functions from keys to values. The fundamental lookup method for a map is: `def get(key): Option[Value]`. The operation "`m get key`" tests whether the map contains an association for the given key. If so, it returns the associated value in a `Some`. If no key is defined in the map, get returns `None`. Maps also define an `apply` method that returns the value associated with a given key directly, without wrapping it in an `Option`. If the key is not defined in the map, an exception is raised.
-    *    - Additions and updates `+`, `++`, `updated`, which let you add new bindings to a map or change existing bindings.
-    *    - Removals `-`, `--`, which remove bindings from a map.
-    *    - Subcollection producers `keys`, `keySet`, `keysIterator`, `values`, `valuesIterator`, which return a map's keys and values separately in various forms.
-    *    - Transformations `filterKeys` and `mapValues`, which produce a new map by filtering and transforming bindings of an existing map.
+    *   - Lookup operations `apply`, `get`, `getOrElse`, `contains`, and `isDefinedAt`. These turn maps into partial functions from keys to values. The fundamental lookup method for a map is: `def get(key): Option[Value]`. The operation "`m get key`" tests whether the map contains an association for the given key. If so, it returns the associated value in a `Some`. If no key is defined in the map, get returns `None`. Maps also define an `apply` method that returns the value associated with a given key directly, without wrapping it in an `Option`. If the key is not defined in the map, an exception is raised.
+    *   - Additions and updates `+`, `++`, `updated`, which let you add new bindings to a map or change existing bindings.
+    *   - Removals `-`, `--`, which remove bindings from a map.
+    *   - Subcollection producers `keys`, `keySet`, `keysIterator`, `values`, `valuesIterator`, which return a map's keys and values separately in various forms.
+    *   - Transformations `filterKeys` and `mapValues`, which produce a new map by filtering and transforming bindings of an existing map.
     *
     * Maps can be created easily:
     */
   def keyAndValueMaps(res0: Int) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap.size should be(res0)
   }
 
   /** Maps contain distinct pairings:
     */
   def distinctPairingsMaps(res0: Int) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "MI" -> "Michigan")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "MI" → "Michigan")
     myMap.size should be(res0)
   }
 
   /** Maps can be added to easily:
     */
   def easilyAddedMaps(res0: Boolean) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "MI" -> "Michigan")
-    val aNewMap = myMap + ("IL" -> "Illinois")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "MI" → "Michigan")
+    val aNewMap = myMap + ("IL" → "Illinois")
     aNewMap.contains("IL") should be(res0)
   }
 
   /** Map values can be iterated:
     */
   def canBeIteratedMaps(res0: Int, res1: String, res2: String) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "MI" -> "Michigan")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "MI" → "Michigan")
 
     val mapValues = myMap.values
     mapValues.size should be(res0)
@@ -55,7 +55,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Maps insertion with duplicate key updates previous entry with subsequent value:
     */
   def duplicatedKeyInsertionMaps(res0: Int, res1: String) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "MI" -> "Meechigan")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "MI" → "Meechigan")
     val mapValues = myMap.values
     mapValues.size should be(res0)
     myMap("MI") should be(res1)
@@ -65,7 +65,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Map keys may be of mixed type:
     */
   def mixedTypeKeysMaps(res0: String, res1: String) {
-    val myMap = Map("Ann Arbor" -> "MI", 49931 -> "MI")
+    val myMap = Map("Ann Arbor" → "MI", 49931 → "MI")
     myMap("Ann Arbor") should be(res0)
     myMap(49931) should be(res1)
   }
@@ -84,7 +84,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Maps may be accessed:
     */
   def mayBeAccessedMaps(res0: String, res1: String) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap("MI") should be(res0)
     myMap("IA") should be(res1)
   }
@@ -92,7 +92,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Map elements can be removed easily:
     */
   def easilyRemovedMaps(res0: Boolean, res1: Boolean) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     val aNewMap = myMap - "MI"
     aNewMap.contains("MI") should be(res0)
     myMap.contains("MI") should be(res1)
@@ -101,7 +101,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Accessing a map by key results in an exception if key is not found:
     */
   def keyNotFoundMaps(res0: Boolean) {
-    val myMap = Map("OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     var blewWithException = true
     intercept[NoSuchElementException] {
       myMap("MI")
@@ -113,7 +113,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Map elements can be removed in multiple:
     */
   def removedInMultipleMaps(res0: Boolean, res1: Boolean, res2: Boolean, res3: Int, res4: Int) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     val aNewMap = myMap -- List("MI", "OH")
 
     aNewMap.contains("MI") should be(res0)
@@ -127,8 +127,8 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Map elements can be removed with a tuple:
     */
   def removedWithTupleMaps(res0: Boolean, res1: Boolean, res2: Boolean, res3: Int, res4: Int) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
-    val aNewMap = myMap -("MI", "WI") // Notice: single '-' operator for tuples
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
+    val aNewMap = myMap - ("MI", "WI") // Notice: single '-' operator for tuples
 
     aNewMap.contains("MI") should be(res0)
     myMap.contains("MI") should be(res1)
@@ -140,7 +140,7 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Attempted removal of nonexistent elements from a map is handled gracefully:
     */
   def attemptedRemovalMaps(res0: Boolean) {
-    val myMap = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     val aNewMap = myMap - "MN"
 
     aNewMap.equals(myMap) should be(res0)
@@ -149,8 +149,8 @@ object Maps extends FlatSpec with Matchers with exercise.Section {
   /** Map equivalency is independent of order:
     */
   def orderIndependentMaps(res0: Boolean) {
-    val myMap1 = Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
-    val myMap2 = Map("WI" -> "Wisconsin", "MI" -> "Michigan", "IA" -> "Iowa", "OH" -> "Ohio")
+    val myMap1 = Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
+    val myMap2 = Map("WI" → "Wisconsin", "MI" → "Michigan", "IA" → "Iowa", "OH" → "Ohio")
 
     myMap1.equals(myMap2) should be(res0)
   }

--- a/site/content/src/main/scala/stdlib/MutableMaps.scala
+++ b/site/content/src/main/scala/stdlib/MutableMaps.scala
@@ -9,20 +9,19 @@ import scala.collection.mutable
   */
 object MutableMaps extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Mutable maps can be created easily:
     */
   def easilyCreatedMutableMaps(res0: Int, res1: Boolean) {
-    val myMap = mutable.Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = mutable.Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap.size should be(res0)
-    myMap += "OR" -> "Oregon"
+    myMap += "OR" → "Oregon"
     myMap contains "OR" should be(res1)
   }
 
   /** Mutable maps can have elements removed:
     */
   def removeElementMutableMaps(res0: Boolean) {
-    val myMap = mutable.Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = mutable.Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap -= "OH"
     myMap contains "OH" should be(res0)
   }
@@ -30,8 +29,8 @@ object MutableMaps extends FlatSpec with Matchers with exercise.Section {
   /** Mutable maps can have tuples of elements removed:
     */
   def removeWithTuplesMutableMaps(res0: Boolean, res1: Int) {
-    val myMap = mutable.Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
-    myMap -=("IA", "OH")
+    val myMap = mutable.Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
+    myMap -= ("IA", "OH")
     myMap contains "OH" should be(res0)
     myMap.size should be(res1)
   }
@@ -39,8 +38,8 @@ object MutableMaps extends FlatSpec with Matchers with exercise.Section {
   /** Mutable maps can have tuples of elements added:
     */
   def addWithTuplesMutableMaps(res0: Boolean, res1: Int) {
-    val myMap = mutable.Map("MI" -> "Michigan", "WI" -> "Wisconsin")
-    myMap +=("IA" -> "Iowa", "OH" -> "Ohio")
+    val myMap = mutable.Map("MI" → "Michigan", "WI" → "Wisconsin")
+    myMap += ("IA" → "Iowa", "OH" → "Ohio")
     myMap contains "OH" should be(res0)
     myMap.size should be(res1)
   }
@@ -48,8 +47,8 @@ object MutableMaps extends FlatSpec with Matchers with exercise.Section {
   /** Mutable maps can have Lists of elements added:
     */
   def addedElementsMutableMaps(res0: Boolean, res1: Int) {
-    val myMap = mutable.Map("MI" -> "Michigan", "WI" -> "Wisconsin")
-    myMap ++= List("IA" -> "Iowa", "OH" -> "Ohio")
+    val myMap = mutable.Map("MI" → "Michigan", "WI" → "Wisconsin")
+    myMap ++= List("IA" → "Iowa", "OH" → "Ohio")
     myMap contains "OH" should be(res0)
     myMap.size should be(res1)
   }
@@ -57,7 +56,7 @@ object MutableMaps extends FlatSpec with Matchers with exercise.Section {
   /** Mutable maps can have Lists of elements removed:
     */
   def removedElementsMutableMaps(res0: Boolean, res1: Int) {
-    val myMap = mutable.Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = mutable.Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap --= List("IA", "OH")
     myMap contains "OH" should be(res0)
     myMap.size should be(res1)
@@ -66,7 +65,7 @@ object MutableMaps extends FlatSpec with Matchers with exercise.Section {
   /** Mutable maps can be cleared:
     */
   def clearMapMutableMaps(res0: Boolean, res1: Int) {
-    val myMap = mutable.Map("MI" -> "Michigan", "OH" -> "Ohio", "WI" -> "Wisconsin", "IA" -> "Iowa")
+    val myMap = mutable.Map("MI" → "Michigan", "OH" → "Ohio", "WI" → "Wisconsin", "IA" → "Iowa")
     myMap.clear() // Convention is to use parens if possible when method called changes state
     myMap contains "OH" should be(res0)
     myMap.size should be(res1)

--- a/site/content/src/main/scala/stdlib/MutableSets.scala
+++ b/site/content/src/main/scala/stdlib/MutableSets.scala
@@ -9,7 +9,6 @@ import scala.collection.mutable
   */
 object MutableSets extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Mutable sets can be created easily:
     */
   def easilyCreatedMutableSets(res0: Int, res1: Boolean) {
@@ -31,7 +30,7 @@ object MutableSets extends FlatSpec with Matchers with exercise.Section {
     */
   def removeWithTuplesMutableSets(res0: Boolean, res1: Int) {
     val mySet = mutable.Set("Michigan", "Ohio", "Wisconsin", "Iowa")
-    mySet -=("Iowa", "Ohio")
+    mySet -= ("Iowa", "Ohio")
     mySet contains "Ohio" should be(res0)
     mySet.size should be(res1)
   }
@@ -40,7 +39,7 @@ object MutableSets extends FlatSpec with Matchers with exercise.Section {
     */
   def addWithTuplesMutableSets(res0: Boolean, res1: Int) {
     val mySet = mutable.Set("Michigan", "Wisconsin")
-    mySet +=("Iowa", "Ohio")
+    mySet += ("Iowa", "Ohio")
     mySet contains "Ohio" should be(res0)
     mySet.size should be(res1)
   }

--- a/site/content/src/main/scala/stdlib/NamedandDefaultArguments.scala
+++ b/site/content/src/main/scala/stdlib/NamedandDefaultArguments.scala
@@ -8,12 +8,11 @@ import org.scalatest._
   */
 object NamedandDefaultArguments extends FlatSpec with Matchers with exercise.Section {
 
-
   /** When calling methods and functions, you can use the name of the variables explicitly in the call, like so:
     *
     * {{{
     * def printName(first:String, last:String) = {
-    *     println(first + " " + last)
+    *    println(first + " " + last)
     * }
     *
     * printName("John","Smith") // Prints "John Smith"
@@ -25,7 +24,7 @@ object NamedandDefaultArguments extends FlatSpec with Matchers with exercise.Sec
     *
     * {{{
     * def printName(first:String = "John", last:String = "Smith") = {
-    *     println(first + " " + last)
+    *    println(first + " " + last)
     * }
     * printName(last = "Jones") // Prints "John Jones"
     * }}}
@@ -34,33 +33,33 @@ object NamedandDefaultArguments extends FlatSpec with Matchers with exercise.Sec
     *
     * {{{
     * class WithoutClassParameters() {
-    *   def addColors(red: Int, green: Int, blue: Int) = {
-    *     (red, green, blue)
-    *   }
+    *  def addColors(red: Int, green: Int, blue: Int) = {
+    *    (red, green, blue)
+    *  }
     *
-    *   def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
-    *     (red, green, blue)
-    *   }
+    *  def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
+    *    (red, green, blue)
+    *  }
     * }
     *
     * class WithClassParameters(val defaultRed: Int, val defaultGreen: Int, val defaultBlue: Int) {
-    *   def addColors(red: Int, green: Int, blue: Int) = {
-    *     (red + defaultRed, green + defaultGreen, blue + defaultBlue)
-    *   }
+    *  def addColors(red: Int, green: Int, blue: Int) = {
+    *    (red + defaultRed, green + defaultGreen, blue + defaultBlue)
+    *  }
     *
-    *   def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
-    *     (red + defaultRed, green + defaultGreen, blue + defaultBlue)
-    *   }
+    *  def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
+    *    (red + defaultRed, green + defaultGreen, blue + defaultBlue)
+    *  }
     * }
     *
     * class WithClassParametersInClassDefinition(val defaultRed: Int = 0, val defaultGreen: Int = 255, val defaultBlue: Int = 100) {
-    *   def addColors(red: Int, green: Int, blue: Int) = {
-    *     (red + defaultRed, green + defaultGreen, blue + defaultBlue)
-    *   }
+    *  def addColors(red: Int, green: Int, blue: Int) = {
+    *    (red + defaultRed, green + defaultGreen, blue + defaultBlue)
+    *  }
     *
-    *   def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
-    *     (red + defaultRed, green + defaultGreen, blue + defaultBlue)
-    *   }
+    *  def addColorsWithDefaults(red: Int = 0, green: Int = 0, blue: Int = 0) = {
+    *    (red + defaultRed, green + defaultGreen, blue + defaultBlue)
+    *  }
     * }
     *
     * }}}
@@ -116,7 +115,7 @@ object NamedandDefaultArguments extends FlatSpec with Matchers with exercise.Sec
   /** Default parameters can be functional too
     */
   def functionalDefaulParametersNamedandDefaultArguments(res0: Int, res1: Int) {
-    def reduce(a: Int, f: (Int, Int) => Int = _ + _): Int = f(a, a)
+    def reduce(a: Int, f: (Int, Int) ⇒ Int = _ + _): Int = f(a, a)
 
     reduce(5) should equal(res0)
     reduce(5, _ * _) should equal(res1)

--- a/site/content/src/main/scala/stdlib/Objects.scala
+++ b/site/content/src/main/scala/stdlib/Objects.scala
@@ -8,7 +8,6 @@ import org.scalatest._
   */
 object Objects extends FlatSpec with Matchers with exercise.Section {
 
-
   /** An object is a singleton. One object, that's it. This object is a replacement of static in Java, and is called upon much in the same way.
     */
   def singletonObjects(res0: String, res1: String, res2: String, res3: String) {
@@ -60,10 +59,10 @@ object Objects extends FlatSpec with Matchers with exercise.Section {
       def academyAwardBestMoviesForYear(x: Short) = {
         //These are match statement, more powerful than Java switch statements!
         x match {
-          case 1930 => Some(new Movie("All Quiet On the Western Front", 1930))
-          case 1931 => Some(new Movie("Cimarron", 1931))
-          case 1932 => Some(new Movie("Grand Hotel", 1932))
-          case _ => None
+          case 1930 ⇒ Some(new Movie("All Quiet On the Western Front", 1930))
+          case 1931 ⇒ Some(new Movie("Cimarron", 1931))
+          case 1932 ⇒ Some(new Movie("Grand Hotel", 1932))
+          case _    ⇒ None
         }
       }
     }
@@ -74,19 +73,19 @@ object Objects extends FlatSpec with Matchers with exercise.Section {
   /** A companion object stores shared variables and values for every instantiated class to share. Having next companion object `SecretAgent`:
     * {{{
     * class SecretAgent(val name: String) {
-    *   def shoot(n: Int) {
-    *     SecretAgent.decrementBullets(n)
-    *   }
+    *  def shoot(n: Int) {
+    *    SecretAgent.decrementBullets(n)
+    *  }
     * }
     *
     * object SecretAgent {
-    *   //This is encapsulated!
-    *   var bullets: Int = 3000
+    *  //This is encapsulated!
+    *  var bullets: Int = 3000
     *
-    *   private def decrementBullets(count: Int) {
-    *     if (bullets - count <= 0) bullets = 0
-    *     else bullets = bullets - count
-    *   }
+    *  private def decrementBullets(count: Int) {
+    *    if (bullets - count <= 0) bullets = 0
+    *    else bullets = bullets - count
+    *  }
     * }
     * }}}
     * Try to understand how bullets are decreasing while agents are shooting.

--- a/site/content/src/main/scala/stdlib/Options.scala
+++ b/site/content/src/main/scala/stdlib/Options.scala
@@ -8,7 +8,6 @@ import org.scalatest._
   */
 object Options extends FlatSpec with Matchers with exercise.Section {
 
-
   /** If you have worked with Java at all in the past, it is very likely that you have come across a `NullPointerException` at some time (other languages will throw similarly named errors in such a case). Usually this happens because some method returns null when you were not expecting it and thus not dealing with that possibility in your client code. A value of `null` is often abused to represent an absent optional value.
     *
     * Scala tries to solve the problem by getting rid of `null` values altogether and providing its own type for representing optional values, i.e. values that may be present or not: the `Option[A]` trait.
@@ -27,7 +26,7 @@ object Options extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * def maybeItWillReturnSomething(flag: Boolean): Option[String] = {
-    *   if (flag) Some("Found value") else None
+    *  if (flag) Some("Found value") else None
     * }
     * }}}
     * Represent `null` with `None` because `null` is a bad idea:
@@ -72,14 +71,14 @@ object Options extends FlatSpec with Matchers with exercise.Section {
   def matchOptions(res0: Float, res1: Float) {
     val someValue: Option[Double] = Some(20.0)
     val value = someValue match {
-      case Some(v) => v
-      case None => 0.0
+      case Some(v) ⇒ v
+      case None    ⇒ 0.0
     }
     value should be(res0)
     val noValue: Option[Double] = None
     val value1 = noValue match {
-      case Some(v) => v
-      case None => 0.0
+      case Some(v) ⇒ v
+      case None    ⇒ 0.0
     }
     value1 should be(res1)
   }

--- a/site/content/src/main/scala/stdlib/ParentClasses.scala
+++ b/site/content/src/main/scala/stdlib/ParentClasses.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object ParentClasses extends FlatSpec with Matchers with exercise.Section {
 
-
   /** In contrast to Java, all values in Scala are objects (including numerical values and functions). Since Scala is class-based, all values are instances of a class.
     *
     * Class hierarchy is linear, a class can only extend from one parent class:
@@ -16,7 +15,7 @@ object ParentClasses extends FlatSpec with Matchers with exercise.Section {
   def allValuesAreObjectsParentClasses(res0: String, res1: String) {
     class Soldier(val firstName: String, val lastName: String) {}
     class Pilot(override val firstName: String, override val lastName: String,
-        val squadron: Long) extends Soldier(firstName, lastName)
+                val squadron: Long) extends Soldier(firstName, lastName)
     val pilot = new Pilot("John", "Yossarian", 256)
     pilot.firstName should be(res0)
     pilot.lastName should be(res1)
@@ -27,7 +26,7 @@ object ParentClasses extends FlatSpec with Matchers with exercise.Section {
   def polymorphicParentClasses(res0: String, res1: String) {
     class Soldier(val firstName: String, val lastName: String) {}
     class Pilot(override val firstName: String, override val lastName: String,
-        val squadron: Long) extends Soldier(firstName, lastName)
+                val squadron: Long) extends Soldier(firstName, lastName)
 
     val pilot = new Pilot("John", "Yossarian", 256)
     val soldier: Soldier = pilot
@@ -56,7 +55,7 @@ object ParentClasses extends FlatSpec with Matchers with exercise.Section {
 
     }
     class Pilot(override val firstName: String, override val lastName: String,
-        val squadron: Long) extends Soldier(firstName, lastName)
+                val squadron: Long) extends Soldier(firstName, lastName)
 
     val pilot = new Pilot("John", "Yossarian", 256)
     val catchNo = new pilot.Catch(22) //using the pilot instance's path, create an catch object for it.

--- a/site/content/src/main/scala/stdlib/PartialFunctions.scala
+++ b/site/content/src/main/scala/stdlib/PartialFunctions.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object PartialFunctions extends FlatSpec with Matchers with exercise.Section {
 
-
   /** A partial function is a `trait` that when implemented can be used as building blocks to determine a solution.  The trait `PartialFunction` requires that the method `isDefinedAt` and `apply` be implemented.
     */
   def partialFunctionPartialFunctions(res0: Int, res1: Int) {
@@ -36,10 +35,10 @@ object PartialFunctions extends FlatSpec with Matchers with exercise.Section {
   def caseStatementsPartialFunctions(res0: Int, res1: Int) {
     //These case statements are called case statements with guards
     val doubleEvens: PartialFunction[Int, Int] = {
-      case x if (x % 2) == 0 => x * 2
+      case x if (x % 2) == 0 ⇒ x * 2
     }
     val tripleOdds: PartialFunction[Int, Int] = {
-      case x if (x % 2) != 0 => x * 3
+      case x if (x % 2) != 0 ⇒ x * 3
     }
 
     val whatToDo = doubleEvens orElse tripleOdds //Here we chain the partial functions together
@@ -52,13 +51,13 @@ object PartialFunctions extends FlatSpec with Matchers with exercise.Section {
   def andThenPartialFunctions(res0: Int, res1: Int) {
     //These are called case statements with guards
     val doubleEvens: PartialFunction[Int, Int] = {
-      case x if (x % 2) == 0 => x * 2
+      case x if (x % 2) == 0 ⇒ x * 2
     }
     val tripleOdds: PartialFunction[Int, Int] = {
-      case x if (x % 2) != 0 => x * 3
+      case x if (x % 2) != 0 ⇒ x * 3
     }
 
-    val addFive = (x: Int) => x + 5
+    val addFive = (x: Int) ⇒ x + 5
     val whatToDo = doubleEvens orElse tripleOdds andThen addFive //Here we chain the partial functions together
     whatToDo(3) should be(res0)
     whatToDo(4) should be(res1)
@@ -68,17 +67,17 @@ object PartialFunctions extends FlatSpec with Matchers with exercise.Section {
     */
   def chainOfLogicPartialFunctions(res0: String, res1: String) {
     val doubleEvens: PartialFunction[Int, Int] = {
-      case x if (x % 2) == 0 => x * 2
+      case x if (x % 2) == 0 ⇒ x * 2
     }
     val tripleOdds: PartialFunction[Int, Int] = {
-      case x if (x % 2) != 0 => x * 3
+      case x if (x % 2) != 0 ⇒ x * 3
     }
 
     val printEven: PartialFunction[Int, String] = {
-      case x if (x % 2) == 0 => "Even"
+      case x if (x % 2) == 0 ⇒ "Even"
     }
     val printOdd: PartialFunction[Int, String] = {
-      case x if (x % 2) != 0 => "Odd"
+      case x if (x % 2) != 0 ⇒ "Odd"
     }
 
     val whatToDo = doubleEvens orElse tripleOdds andThen (printEven orElse printOdd)

--- a/site/content/src/main/scala/stdlib/PartiallyAppliedFunctions.scala
+++ b/site/content/src/main/scala/stdlib/PartiallyAppliedFunctions.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object PartiallyAppliedFunctions extends FlatSpec with Matchers with exercise.Section {
 
-
   /** A partially applied function is a function that you do not apply any or all the arguments, creating another function. This partially applied function doesn't apply any arguments.
     */
   def partiallyAppliedPartiallyAppliedFunctions(res0: Int, res1: Int) {
@@ -42,7 +41,7 @@ object PartiallyAppliedFunctions extends FlatSpec with Matchers with exercise.Se
   /** Currying allows you to create specialized version of generalized function
     */
   def specializedVersionPartiallyAppliedFunctions(res0: List[Int], res1: List[Int]) {
-    def customFilter(f: Int => Boolean)(xs: List[Int]) = {
+    def customFilter(f: Int ⇒ Boolean)(xs: List[Int]) = {
       xs filter f
     }
     def onlyEven(x: Int) = x % 2 == 0

--- a/site/content/src/main/scala/stdlib/PatternMatching.scala
+++ b/site/content/src/main/scala/stdlib/PatternMatching.scala
@@ -12,12 +12,12 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * object MatchTest1 extends App {
-    *   def matchTest(x: Int): String = x match {
-    *     case 1 => "one"
-    *     case 2 => "two"
-    *     case _ => "many"
-    *   }
-    *   println(matchTest(3))
+    *  def matchTest(x: Int): String = x match {
+    *    case 1 => "one"
+    *    case 2 => "two"
+    *    case _ => "many"
+    *  }
+    *  println(matchTest(3))
     * }
     * }}}
     *
@@ -32,10 +32,13 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     val stuff = "blue"
 
     val myStuff = stuff match {
-      case "red" => println("RED"); 1
-      case "blue" => println("BLUE"); 2
-      case "green" => println("GREEN"); 3
-      case _ => println(stuff); 0 //case _ will trigger if all other cases fail.
+      case "red"   ⇒
+        println("RED"); 1
+      case "blue"  ⇒
+        println("BLUE"); 2
+      case "green" ⇒
+        println("GREEN"); 3
+      case _       ⇒ println(stuff); 0 //case _ will trigger if all other cases fail.
     }
 
     myStuff should be(res0)
@@ -47,10 +50,10 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     val stuff = "blue"
 
     val myStuff = stuff match {
-      case "red" => (255, 0, 0)
-      case "green" => (0, 255, 0)
-      case "blue" => (0, 0, 255)
-      case _ => println(stuff); 0
+      case "red"   ⇒ (255, 0, 0)
+      case "green" ⇒ (0, 255, 0)
+      case "blue"  ⇒ (0, 0, 255)
+      case _       ⇒ println(stuff); 0
     }
 
     myStuff should be(res0, res1, res2)
@@ -60,10 +63,10 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def complexExpressionsPatternMatching(res0: String) {
     def goldilocks(expr: Any) = expr match {
-      case ("porridge", "Papa") => "Papa eating porridge"
-      case ("porridge", "Mama") => "Mama eating porridge"
-      case ("porridge", "Baby") => "Baby eating porridge"
-      case _ => "what?"
+      case ("porridge", "Papa") ⇒ "Papa eating porridge"
+      case ("porridge", "Mama") ⇒ "Mama eating porridge"
+      case ("porridge", "Baby") ⇒ "Baby eating porridge"
+      case _                    ⇒ "what?"
     }
 
     goldilocks(("porridge", "Mama")) should be(res0)
@@ -73,10 +76,10 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def wildcardParsPatternMatching(res0: String, res1: String) {
     def goldilocks(expr: Any) = expr match {
-      case ("porridge", _) => "eating"
-      case ("chair", "Mama") => "sitting"
-      case ("bed", "Baby") => "sleeping"
-      case _ => "what?"
+      case ("porridge", _)   ⇒ "eating"
+      case ("chair", "Mama") ⇒ "sitting"
+      case ("bed", "Baby")   ⇒ "sleeping"
+      case _                 ⇒ "what?"
     }
 
     goldilocks(("porridge", "Papa")) should be(res0)
@@ -87,10 +90,10 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def substitutePartsPatternMatching(res0: String, res1: String) {
     def goldilocks(expr: Any) = expr match {
-      case ("porridge", bear) => bear + " said someone's been eating my porridge"
-      case ("chair", bear) => bear + " said someone's been sitting in my chair"
-      case ("bed", bear) => bear + " said someone's been sleeping in my bed"
-      case _ => "what?"
+      case ("porridge", bear) ⇒ bear + " said someone's been eating my porridge"
+      case ("chair", bear)    ⇒ bear + " said someone's been sitting in my chair"
+      case ("bed", bear)      ⇒ bear + " said someone's been sleeping in my bed"
+      case _                  ⇒ "what?"
     }
 
     goldilocks(("porridge", "Papa")) should be(res0)
@@ -98,26 +101,26 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
   }
 
   //TODO: Improve compiler to ignore regular expressions in the body of the exercise
-//  /** regularExpressionsPatternMatching
-//    *
-//    * Pattern matching can be done on regular expression groups:
-//    */
-//  def regularExpressionsPatternMatching(res0: String, res1: String) {
-//    val EatingRegularExpression = """Eating Alert: bear=([^,]+),\s+source=(.+)""".r //.r turns a String to a regular expression
-//    val SittingRegularExpression =
-//      """Sitting Alert: bear=([^,]+),\s+source=(.+)""".r
-//    val SleepingRegularExpression = """Sleeping Alert: bear=([^,]+),\s+source=(.+)""".r
-//
-//    def goldilocks(expr: String) = expr match {
-//      case (EatingRegularExpression(bear, source)) => "%s said someone's been eating my %s".format(bear, source)
-//      case (SittingRegularExpression(bear, source)) => "%s said someone's been sitting on my %s".format(bear, source)
-//      case (SleepingRegularExpression(bear, source)) => "%s said someone's been sleeping in my %s".format(bear, source)
-//      case _ => "what?"
-//    }
-//
-//    goldilocks("Eating Alert: bear=Papa, source=porridge") should be(res0)
-//    goldilocks("Sitting Alert: bear=Mama, source=chair") should be(res1)
-//  }
+  //  /** regularExpressionsPatternMatching
+  //    *
+  //    * Pattern matching can be done on regular expression groups:
+  //    */
+  //  def regularExpressionsPatternMatching(res0: String, res1: String) {
+  //    val EatingRegularExpression = """Eating Alert: bear=([^,]+),\s+source=(.+)""".r //.r turns a String to a regular expression
+  //    val SittingRegularExpression =
+  //      """Sitting Alert: bear=([^,]+),\s+source=(.+)""".r
+  //    val SleepingRegularExpression = """Sleeping Alert: bear=([^,]+),\s+source=(.+)""".r
+  //
+  //    def goldilocks(expr: String) = expr match {
+  //      case (EatingRegularExpression(bear, source)) => "%s said someone's been eating my %s".format(bear, source)
+  //      case (SittingRegularExpression(bear, source)) => "%s said someone's been sitting on my %s".format(bear, source)
+  //      case (SleepingRegularExpression(bear, source)) => "%s said someone's been sleeping in my %s".format(bear, source)
+  //      case _ => "what?"
+  //    }
+  //
+  //    goldilocks("Eating Alert: bear=Papa, source=porridge") should be(res0)
+  //    goldilocks("Sitting Alert: bear=Mama, source=chair") should be(res1)
+  //  }
 
   /** A backquote can be used to refer to a stable variable in scope to create a case statement. This prevents what is called "Variable Shadowing"
     */
@@ -125,10 +128,10 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     val foodItem = "porridge"
 
     def goldilocks(expr: Any) = expr match {
-      case (`foodItem`, _) => "eating"
-      case ("chair", "Mama") => "sitting"
-      case ("bed", "Baby") => "sleeping"
-      case _ => "what?"
+      case (`foodItem`, _)   ⇒ "eating"
+      case ("chair", "Mama") ⇒ "sitting"
+      case ("bed", "Baby")   ⇒ "sleeping"
+      case _                 ⇒ "what?"
     }
 
     goldilocks(("porridge", "Papa")) should be(res0)
@@ -141,8 +144,8 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def stableVariablePatternMatching(res0: Boolean, res1: Boolean, res2: Boolean) {
     def patternEquals(i: Int, j: Int) = j match {
-      case `i` => true
-      case _ => false
+      case `i` ⇒ true
+      case _   ⇒ false
     }
     patternEquals(3, 3) should be(res0)
     patternEquals(7, 9) should be(res1)
@@ -153,8 +156,8 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def againstListsPatternMatching(res0: Int) {
     val secondElement = List(1, 2, 3) match {
-      case x :: xs => xs.head
-      case _ => 0
+      case x :: xs ⇒ xs.head
+      case _       ⇒ 0
     }
 
     secondElement should be(res0)
@@ -164,8 +167,8 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def againstListsIIPatternMatching(res0: Int) {
     val secondElement = List(1, 2, 3) match {
-      case x :: y :: xs => y
-      case _ => 0
+      case x :: y :: xs ⇒ y
+      case _            ⇒ 0
     }
 
     secondElement should be(res0)
@@ -175,8 +178,8 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def againstListsIIIPatternMatching(res0: Int) {
     val secondElement = List(1) match {
-      case x :: y :: xs => y
-      case _ => 0
+      case x :: y :: xs ⇒ y
+      case _            ⇒ 0
     }
 
     secondElement should be(res0)
@@ -186,8 +189,8 @@ object PatternMatching extends FlatSpec with Matchers with exercise.Section {
     */
   def againstListsIVPatternMatching(res0: Int) {
     val r = List(1, 2, 3) match {
-      case x :: y :: Nil => y
-      case _ => 0
+      case x :: y :: Nil ⇒ y
+      case _             ⇒ 0
     }
 
     r should be(res0)

--- a/site/content/src/main/scala/stdlib/Preconditions.scala
+++ b/site/content/src/main/scala/stdlib/Preconditions.scala
@@ -8,7 +8,6 @@ import org.scalatest._
   */
 object Preconditions extends FlatSpec with Matchers with exercise.Section {
 
-
   /** One of the benefits of object-oriented programming is that it allows you to encapsulate data inside objects so that you can ensure the data is valid throughout its lifetime. In the case of an immutable object such as *Rational*, this means that you should ensure the data is valid when the object is constructed.
     *
     * Given that a zero denominator is an invalid state for a *Rational* number, you should not let a *Rational* be constructed if a zero is passed in the d parameter.
@@ -19,8 +18,8 @@ object Preconditions extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class Rational(n: Int, d: Int) {
-    *   require(d != 0)
-    *   override def toString = n +"/"+ d
+    *  require(d != 0)
+    *  override def toString = n +"/"+ d
     * }
     * }}}
     *
@@ -30,11 +29,11 @@ object Preconditions extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class WithParameterRequirement(val myValue: Int) {
-    *   require(myValue != 0)
+    *  require(myValue != 0)
     *
-    *   def this(someValue: String) {
-    *     this(someValue.size)
-    *   }
+    *  def this(someValue: String) {
+    *    this(someValue.size)
+    *  }
     * }
     * }}}
     * On precondition violation, intercept expects type of exception thrown. *Instruction: use Intercept to catch the type of exception thrown by an invalid precondition*

--- a/site/content/src/main/scala/stdlib/Ranges.scala
+++ b/site/content/src/main/scala/stdlib/Ranges.scala
@@ -70,7 +70,7 @@ object Ranges extends FlatSpec with Matchers with exercise.Section {
       * If you want to create a range that is exclusive of its upper limit, then use the convenience method `until` instead of `to`: `1 until 3` generates `Range(1, 2)`.
       *
       * Ranges are represented in constant space, because they can be defined by just three numbers: their start, their end, and the stepping value. Because of this representation, most operations on ranges are extremely fast.
-      * */
+      */
   }
 
 }

--- a/site/content/src/main/scala/stdlib/RepeatedParameters.scala
+++ b/site/content/src/main/scala/stdlib/RepeatedParameters.scala
@@ -8,14 +8,13 @@ import org.scalatest._
   */
 object RepeatedParameters extends FlatSpec with Matchers with exercise.Section {
 
-
   /** A repeated parameter must be the last parameter and this will let you add as many extra parameters as needed.
     *
     * Given:
     *
     * {{{
     * def repeatedParameterMethod(x: Int, y: String, z: Any*) = {
-    *   "%d %ss can give you %s".format(x, y, z.mkString(", "))
+    *  "%d %ss can give you %s".format(x, y, z.mkString(", "))
     * }
     * }}}
     * Resolve:

--- a/site/content/src/main/scala/stdlib/SequencesandArrays.scala
+++ b/site/content/src/main/scala/stdlib/SequencesandArrays.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object SequencesandArrays extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Scala provides a data structure, the array, which stores a fixed-size sequential collection of elements of the same type. An array is used to store a collection of data, but it is often more useful to think of an array as a collection of variables of the same type.
     *
     * A list can be converted to an array:
@@ -33,14 +32,14 @@ object SequencesandArrays extends FlatSpec with Matchers with exercise.Section {
   /** You can create a sequence from a for comprehension:
     */
   def fromForComprehensionSequencesandArrays(res0: List[Int]) {
-    val s = for (v <- 1 to 4) yield v
+    val s = for (v ← 1 to 4) yield v
     s.toList should be(res0)
   }
 
   /** You can create a sequence from a for comprehension with a condition:
     */
   def withConditionSequencesandArrays(res0: List[Int]) {
-    val s = for (v <- 1 to 10 if v % 3 == 0) yield v
+    val s = for (v ← 1 to 10 if v % 3 == 0) yield v
     s.toList should be(res0)
   }
 

--- a/site/content/src/main/scala/stdlib/Sets.scala
+++ b/site/content/src/main/scala/stdlib/Sets.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object Sets extends FlatSpec with Matchers with exercise.Section {
 
-
   /** `Set`s are `Iterable`s that contain no duplicate elements. The operations on sets are summarized in the following table for general sets and in the table after that for mutable sets. They fall into the following categories:
     *
     * *   **Tests** `contains`, `apply`, `subsetOf`. The `contains` method asks whether a set contains a given element. The `apply` method for a set is the same as `contains`, so `set(elem)` is the same as `set contains elem`. That means sets can also be used as test functions that return true for the elements they contain.
@@ -82,7 +81,7 @@ object Sets extends FlatSpec with Matchers with exercise.Section {
     */
   def tupleRemovingSets(res0: Boolean, res1: Boolean, res2: Int) {
     val mySet = Set("Michigan", "Ohio", "Wisconsin", "Iowa")
-    val aNewSet = mySet -("Michigan", "Ohio") // Notice: single '-' operator for tuples
+    val aNewSet = mySet - ("Michigan", "Ohio") // Notice: single '-' operator for tuples
 
     aNewSet.contains("Michigan") should be(res0)
     aNewSet.contains("Wisconsin") should be(res1)
@@ -103,7 +102,7 @@ object Sets extends FlatSpec with Matchers with exercise.Section {
   def easilyIteratedSets(res0: Int) {
     val mySet = Set(1, 3, 4, 9)
     var sum = 0
-    for (i <- mySet)
+    for (i ← mySet)
       sum = sum + i //Of course this is the same thing as mySet.reduce(_ + _) or mySet.sum
 
     sum should be(res0)

--- a/site/content/src/main/scala/stdlib/Traits.scala
+++ b/site/content/src/main/scala/stdlib/Traits.scala
@@ -6,15 +6,14 @@ import org.scalatest._
   */
 object Traits extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Similar to *interfaces* in Java, traits are used to define object types by specifying the signature of the supported methods. Unlike Java, Scala allows traits to be partially implemented; i.e. it is possible to define default implementations for some methods. In contrast to classes, traits may not have constructor parameters.
     *
     * Here is an example:
     *
     * {{{
     * trait Similarity {
-    *   def isSimilar(x: Any): Boolean
-    *   def isNotSimilar(x: Any): Boolean = !isSimilar(x)
+    *  def isSimilar(x: Any): Boolean
+    *  def isNotSimilar(x: Any): Boolean = !isSimilar(x)
     * }
     * }}}
     *
@@ -22,19 +21,19 @@ object Traits extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * class Point(xc: Int, yc: Int) extends Similarity {
-    *   var x: Int = xc
-    *   var y: Int = yc
-    *   def isSimilar(obj: Any) =
-    *     obj.isInstanceOf[Point] &&
-    *     obj.asInstanceOf[Point].x == x
+    *  var x: Int = xc
+    *  var y: Int = yc
+    *  def isSimilar(obj: Any) =
+    *    obj.isInstanceOf[Point] &&
+    *    obj.asInstanceOf[Point].x == x
     * }
     * object TraitsTest extends App {
-    *   val p1 = new Point(2, 3)
-    *   val p2 = new Point(2, 4)
-    *   val p3 = new Point(3, 3)
-    *   println(p1.isNotSimilar(p2))
-    *   println(p1.isNotSimilar(p3))
-    *   println(p1.isNotSimilar(2))
+    *  val p1 = new Point(2, 3)
+    *  val p2 = new Point(2, 4)
+    *  val p3 = new Point(3, 3)
+    *  println(p1.isNotSimilar(p2))
+    *  println(p1.isNotSimilar(p3))
+    *  println(p1.isNotSimilar(2))
     * }
     * }}}
     * Here is the output of the program:
@@ -54,12 +53,11 @@ object Traits extends FlatSpec with Matchers with exercise.Section {
       def listen(event: Event): String
     }
 
-
     class MyListener extends EventListener {
       def listen(event: Event): String = {
         event match {
-          case Event("Moose Stampede") => "An unfortunate moose stampede occurred"
-          case _ => "Nothing of importance occurred"
+          case Event("Moose Stampede") ⇒ "An unfortunate moose stampede occurred"
+          case _                       ⇒ "Nothing of importance occurred"
         }
       }
     }
@@ -83,8 +81,8 @@ object Traits extends FlatSpec with Matchers with exercise.Section {
     class MyListener extends OurListener with EventListener {
       def listen(event: Event): String = {
         event match {
-          case Event("Woodchuck Stampede") => "An unfortunate woodchuck stampede occurred"
-          case _ => "Nothing of importance occurred"
+          case Event("Woodchuck Stampede") ⇒ "An unfortunate woodchuck stampede occurred"
+          case _                           ⇒ "Nothing of importance occurred"
         }
       }
     }
@@ -106,8 +104,8 @@ object Traits extends FlatSpec with Matchers with exercise.Section {
     class MyListener extends EventListener {
       def listen(event: Event): String = {
         event match {
-          case Event("Moose Stampede") => "An unfortunate moose stampede occurred"
-          case _ => "Nothing of importance occurred"
+          case Event("Moose Stampede") ⇒ "An unfortunate moose stampede occurred"
+          case _                       ⇒ "Nothing of importance occurred"
         }
       }
     }
@@ -146,7 +144,6 @@ object Traits extends FlatSpec with Matchers with exercise.Section {
 
     val welder = new Welder
     welder.weld()
-
 
     val baker = new Baker
     baker.bake()

--- a/site/content/src/main/scala/stdlib/Traversables.scala
+++ b/site/content/src/main/scala/stdlib/Traversables.scala
@@ -9,7 +9,6 @@ import Stream.cons
   */
 object Traversables extends FlatSpec with Matchers with exercise.Section {
 
-
   /** At the top of the collection hierarchy is trait *Traversable*. Its only abstract operation is `foreach`:
     *
     * {{{
@@ -59,7 +58,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     */
   def flatMapOfOptionsTraversables(res0: List[Int]) {
     val list = List(1, 2, 3, 4, 5)
-    val result = list.flatMap(it => if (it % 2 == 0) Some(it) else None)
+    val result = list.flatMap(it ⇒ if (it % 2 == 0) Some(it) else None)
     result should be(res0)
   }
 
@@ -68,7 +67,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   def collectFunctionTraversables(res0: List[Int]) {
     val list = List(4, 6, 7, 8, 9, 13, 14)
     val result = list.collect {
-      case x: Int if (x % 2 == 0) => x * 3
+      case x: Int if (x % 2 == 0) ⇒ x * 3
     }
     result should be(res0)
   }
@@ -78,10 +77,10 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   def collectFunctionIITraversables(res0: List[Int]) {
     val list = List(4, 6, 7, 8, 9, 13, 14)
     val partialFunction1: PartialFunction[Int, Int] = {
-      case x: Int if x % 2 == 0 => x * 3
+      case x: Int if x % 2 == 0 ⇒ x * 3
     }
     val partialFunction2: PartialFunction[Int, Int] = {
-      case y: Int if y % 2 != 0 => y * 4
+      case y: Int if y % 2 != 0 ⇒ y * 4
     }
     val result = list.collect(partialFunction1 orElse partialFunction2)
     result should be(res0)
@@ -92,7 +91,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     */
   def foreachFunctionTraversables(res0: List[Int]) {
     val list = List(4, 6, 7, 8, 9, 13, 14)
-    list.foreach(num => println(num * 4))
+    list.foreach(num ⇒ println(num * 4))
     list should be(res0)
   }
 
@@ -165,7 +164,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   /** `toMap` will convert any *Traversable* to a *Map*. How it's used depends on the original collection; if it's a *List* or *Seq*, it should be of parameterized type *Tuple2*.
     */
   def toMapFunctionTraversables(res0: Boolean) {
-    val list = List("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val list = List("Phoenix" → "Arizona", "Austin" → "Texas")
     val result = list.toMap
     result.isInstanceOf[Map[_, _]] should be(res0)
   }
@@ -173,7 +172,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   /** `toMap` will convert a *Set* to a *Map*, it should be of parameterized type *Tuple2*.
     */
   def toMapFunctionIITraversables(res0: Boolean) {
-    val set = Set("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val set = Set("Phoenix" → "Arizona", "Austin" → "Texas")
     val result = set.toMap
     result.isInstanceOf[Map[_, _]] should be(res0)
   }
@@ -181,7 +180,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   /** `isEmpty` is pretty self evident
     */
   def isEmptyFunctionTraversables(res0: Boolean, res1: Boolean) {
-    val map = Map("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val map = Map("Phoenix" → "Arizona", "Austin" → "Texas")
     map.isEmpty should be(res0)
 
     val set = Set()
@@ -191,7 +190,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   /** `nonEmpty` is pretty self evident too
     */
   def nonEmptyFunctionTraversables(res0: Boolean, res1: Boolean) {
-    val map = Map("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val map = Map("Phoenix" → "Arizona", "Austin" → "Texas")
     map.nonEmpty should be(res0)
 
     val set = Set()
@@ -201,16 +200,15 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   /** `size` provides the size of the traversable
     */
   def sizeFunctionTraversables(res0: Int) {
-    val map = Map("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val map = Map("Phoenix" → "Arizona", "Austin" → "Texas")
     map.size should be(res0)
   }
 
   /** `hasDefiniteSize` will return `true` if there is traversable that has a finite end, otherwise `false`.
     */
   def hasDefiniteSizeFunctionTraversables(res0: Boolean, res1: Boolean) {
-    val map = Map("Phoenix" -> "Arizona", "Austin" -> "Texas")
+    val map = Map("Phoenix" → "Arizona", "Austin" → "Texas")
     map.hasDefiniteSize should be(res0)
-
 
     val stream = cons(0, cons(1, Stream.empty))
     stream.hasDefiniteSize should be(res1)
@@ -365,31 +363,31 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     val array = Array(87, 44, 5, 4, 200, 10, 39, 100)
 
     val oddAndSmallPartial: PartialFunction[Int, String] = {
-      case x: Int if x % 2 != 0 && x < 100 => "Odd and less than 100"
+      case x: Int if x % 2 != 0 && x < 100 ⇒ "Odd and less than 100"
     }
 
     val evenAndSmallPartial: PartialFunction[Int, String] = {
-      case x: Int if x != 0 && x % 2 == 0 && x < 100 => "Even and less than 100"
+      case x: Int if x != 0 && x % 2 == 0 && x < 100 ⇒ "Even and less than 100"
     }
 
     val negativePartial: PartialFunction[Int, String] = {
-      case x: Int if x < 0 => "Negative Number"
+      case x: Int if x < 0 ⇒ "Negative Number"
     }
 
     val largePartial: PartialFunction[Int, String] = {
-      case x: Int if x > 99 => "Large Number"
+      case x: Int if x > 99 ⇒ "Large Number"
     }
 
     val zeroPartial: PartialFunction[Int, String] = {
-      case x: Int if x == 0 => "Zero"
+      case x: Int if x == 0 ⇒ "Zero"
     }
 
     val result = array groupBy {
       oddAndSmallPartial orElse
-          evenAndSmallPartial orElse
-          negativePartial orElse
-          largePartial orElse
-          zeroPartial
+        evenAndSmallPartial orElse
+        negativePartial orElse
+        largePartial orElse
+        zeroPartial
     }
 
     (result("Even and less than 100") size) should be(res0)
@@ -427,16 +425,16 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   def foldLeftFunctionTraversables(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int) {
     val list = List(5, 4, 3, 2, 1)
     val result = (0 /: list) {
-      (`running total`, `next element`) => `running total` - `next element`
+      (`running total`, `next element`) ⇒ `running total` - `next element`
     }
     result should be(res0)
 
     val result2 = list.foldLeft(0) {
-      (`running total`, `next element`) => `running total` - `next element`
+      (`running total`, `next element`) ⇒ `running total` - `next element`
     }
     result2 should be(res1)
 
-    val result3 = (0 /: list) (_ - _) //Short hand
+    val result3 = (0 /: list)(_ - _) //Short hand
     result3 should be(res2)
 
     val result4 = list.foldLeft(0)(_ - _)
@@ -452,16 +450,16 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
   def foldRightFunctionTraversables(res0: Int, res1: Int, res2: Int, res3: Int, res4: Int) {
     val list = List(5, 4, 3, 2, 1)
     val result = (list :\ 0) {
-      (`next element`, `running total`) => `next element` - `running total`
+      (`next element`, `running total`) ⇒ `next element` - `running total`
     }
     result should be(res0)
 
     val result2 = (list :\ 0) {
-      (`next element`, `running total`) => `next element` - `running total`
+      (`next element`, `running total`) ⇒ `next element` - `running total`
     }
     result2 should be(res1)
 
-    val result3 = (list :\ 0) (_ - _) //Short hand
+    val result3 = (list :\ 0)(_ - _) //Short hand
     result3 should be(res2)
 
     val result4 = list.foldRight(0)(_ - _)
@@ -516,7 +514,6 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     (1 to MAX_SIZE) reduceLeft (_ + _)
     val reduceLeftEndTime = new java.util.Date
 
-
     val reduceRightStartTime = new java.util.Date
     (1 to MAX_SIZE) reduceRight (_ + _)
     val reduceRightEndTime = new java.util.Date
@@ -559,7 +556,7 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     val stringBuilder = new StringBuilder()
     val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     stringBuilder.append("I want all numbers 6-12: ")
-    list.filter(it => it > 5 && it < 13).addString(stringBuilder, ",")
+    list.filter(it ⇒ it > 5 && it < 13).addString(stringBuilder, ",")
     stringBuilder.mkString should be(res0)
   }
 
@@ -574,11 +571,12 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
     }
 
     val l1 = lst.map {
-      x => addHistory("Doubling %s".format(x))
+      x ⇒
+        addHistory("Doubling %s".format(x))
         x * 2
     }
 
-    val l2 = l1.map { x => addHistory("Adding 1 to %s".format(x)); x + 1 }
+    val l2 = l1.map { x ⇒ addHistory("Adding 1 to %s".format(x)); x + 1 }
 
     history(0) should be(res0)
     history(1) should be(res1)
@@ -589,8 +587,8 @@ object Traversables extends FlatSpec with Matchers with exercise.Section {
 
     history = List[String]()
 
-    lst.view.map { x => addHistory("Doubling %s".format(x)); x * 2 }.map {
-      x => addHistory("Adding 1 to %s".format(x)); x + 1
+    lst.view.map { x ⇒ addHistory("Doubling %s".format(x)); x * 2 }.map {
+      x ⇒ addHistory("Adding 1 to %s".format(x)); x + 1
     }.force
 
     history(0) should be(res6)

--- a/site/content/src/main/scala/stdlib/Tuples.scala
+++ b/site/content/src/main/scala/stdlib/Tuples.scala
@@ -9,7 +9,6 @@ import org.scalatest._
   */
 object Tuples extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Scala tuple combines a fixed number of items together so that they can be passed around as a whole. They are one indexed. Unlike an array or list, a tuple can hold objects with different types but they are also immutable. Here is an example of a tuple holding an integer, a string, and the console:
     *
     * {{{

--- a/site/content/src/main/scala/stdlib/TypeSignatures.scala
+++ b/site/content/src/main/scala/stdlib/TypeSignatures.scala
@@ -6,7 +6,6 @@ import org.scalatest._
   */
 object TypeSignatures extends FlatSpec with Matchers with exercise.Section {
 
-
   /** A method's *type signature* comprises its name, the number, order, and types of its parameters, if any, and its result type. The type signature of a class, trait, or singleton object comprises its name, the type signatures of all of its members and constructors, and its declared inheritance and mixin relations.
     *
     * In Java you declare a generic type within a `<>`, in Scala it is `[]`
@@ -98,20 +97,20 @@ object TypeSignatures extends FlatSpec with Matchers with exercise.Section {
     *
     * {{{
     * trait Randomizer[A] {
-    *   def draw(): A
+    *  def draw(): A
     * }
     *
     * class IntRandomizer extends Randomizer[Int] {
-    *   def draw() = {
-    *     import util.Random
-    *     Random.nextInt()
-    *   }
+    *  def draw() = {
+    *    import util.Random
+    *    Random.nextInt()
+    *  }
     * }
     *
     * val intRand = new IntRandomizer
     *
     * intercept[ClassCastException] {
-    *   intRand.asInstanceOf[String] //intRand cannot be cast to String
+    *  intRand.asInstanceOf[String] //intRand cannot be cast to String
     * }
     * }}}
     *

--- a/site/content/src/main/scala/stdlib/TypeVariance.scala
+++ b/site/content/src/main/scala/stdlib/TypeVariance.scala
@@ -7,7 +7,6 @@ import org.scalatest._
   */
 object TypeVariance extends FlatSpec with Matchers with exercise.Section {
 
-
   /** A traditional objection to static typing is that it has much syntactic overhead. Scala alleviates this by providing *type inference*.
     *
     * The classic method for type inference in functional programming languages is *Hindley-Milner*, and it was first employed in ML.
@@ -74,31 +73,31 @@ object TypeVariance extends FlatSpec with Matchers with exercise.Section {
   /** Scala's type system has to account for class hierarchies together with polymorphism. Class hierarchies allow the expression of subtype relationships. A central question that comes up when mixing OO with polymorphism is: if `T'` is a subclass of `T`, is `Container[T']` considered a subclass of `Container[T]`? Variance annotations allow you to express the following relationships between class hierarchies & polymorphic types:
     *
     * ####Covariant:
-    *    - `C[T']` is a subclass of `C[T]`
-    *    - Scala notation: `[+T]`
+    *   - `C[T']` is a subclass of `C[T]`
+    *   - Scala notation: `[+T]`
     *
     * ####Contravariant:
-    *    - `C[T]` is a subclass of `C[T']`
-    *    - Scala notation: `[-T]`
+    *   - `C[T]` is a subclass of `C[T']`
+    *   - Scala notation: `[-T]`
     *
     * ####Invariant:
-    *    - `C[T]` and `C[T']` are not related
-    *    - Scala notation: `[T]`
+    *   - `C[T]` and `C[T']` are not related
+    *   - Scala notation: `[T]`
     *
     *
     * That one probably blew your mind. Now if you assign a type to the instantiation that is different to the variable type, you'll have problems. You may want to take time after this koan to compare and contrast with the previous one.
     *
     * {{{
     * class MyContainer[A](a: A)(implicit manifest: scala.reflect.Manifest[A]) {
-    *   private[this] var item = a
+    *  private[this] var item = a
     *
-    *   def get = item
+    *  def get = item
     *
-    *   def set(a: A) {
-    *     item = a
-    *   }
+    *  def set(a: A) {
+    *    item = a
+    *  }
     *
-    *   def contents = manifest.runtimeClass.getSimpleName
+    *  def contents = manifest.runtimeClass.getSimpleName
     * }
     *
     * // Uncomment the following line

--- a/site/content/src/main/scala/stdlib/UniformAccessPrinciple.scala
+++ b/site/content/src/main/scala/stdlib/UniformAccessPrinciple.scala
@@ -8,7 +8,6 @@ import org.scalatest._
   */
 object UniformAccessPrinciple extends FlatSpec with Matchers with exercise.Section {
 
-
   /** The Scala language implements a programming concept known as the [Uniform Access Principle](http://en.wikipedia.org/wiki/Uniform_access_principle) which was first put forth by Bertrand Meyer, inventor of the Eiffel programming language.
     *
     * This principle states that variables and parameterless functions should be accessed using the same syntax. Scala supports this principle by not allowing parentheses to be placed at call sites of parameterless functions. As a result, a parameterless function definition can be changed to a val, or vice versa, without affecting client code.
@@ -18,15 +17,15 @@ object UniformAccessPrinciple extends FlatSpec with Matchers with exercise.Secti
     * {{{
     * class CalculatesAgeUsingMethod(var currentYear: Int, birthYear: Int) {
     *
-    *   def age = currentYear - birthYear
+    *  def age = currentYear - birthYear
     *
-    *   // calculated when method is called
+    *  // calculated when method is called
     * }
     *
     * class CalculatesAgeUsingProperty(var currentYear: Int, birthYear: Int) {
-    *   // does age stay up to date if defined as a var instead of a val?
-    *   val age = currentYear - birthYear
-    *   // calculated at instantiation, returns property when called
+    *  // does age stay up to date if defined as a var instead of a val?
+    *  val age = currentYear - birthYear
+    *  // calculated at instantiation, returns property when called
     * }
     * }}}
     * Can access age as parameterless method:
@@ -40,7 +39,8 @@ object UniformAccessPrinciple extends FlatSpec with Matchers with exercise.Secti
       * {{{
       * val me = new CalculatesAgeUsingMethod(2010, 2003)
       * //me.age() should be (7)
-      * }}} */
+      * }}}
+      */
   }
 
   /** Can access age as property:

--- a/site/content/src/main/scala/stdlib/ValandVar.scala
+++ b/site/content/src/main/scala/stdlib/ValandVar.scala
@@ -6,7 +6,6 @@ import org.scalatest._
   */
 object ValandVar extends FlatSpec with Matchers with exercise.Section {
 
-
   /** Scala allows one to decide whether a variable is immutable or mutable. Immutable is read-only whereas mutable is read-write. Immutable variables are declared with the keyword `val`.
     *
     * {{{
@@ -56,7 +55,8 @@ object ValandVar extends FlatSpec with Matchers with exercise.Section {
       * {{{
       * stringArray(3) = "foo"
       * }}}
-      * will not result in any error. */
+      * will not result in any error.
+      */
   }
 
 }


### PR DESCRIPTION
We want the standard Compile configuration to behave "normally" so that plugins like Scalariform will interface nicely with the exercise compiler.

I've rearranged the various tasks/configurations in the plugin so it behaves that way.