### PR TITLE
Fix behavior of code formatter for comments.

### DIFF
--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/comments.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/comments.scala
@@ -299,9 +299,18 @@ private[compiler] object CommentRendering {
   }
 
   private[this] def formatCode(code: String): String = {
-    def wrap(code: String): String = s"""object Wrapper { $code }"""
+    def wrap(code: String): String = s"""// format: OFF
+      |object Wrapper {
+      |// format: ON
+      |$code
+      |// format: OFF
+      |}""".stripMargin
+
     def unwrap(code: String): String =
-      code.split("\n").drop(1).dropRight(1).map(_.drop(2)).mkString("\n")
+      code.split("\n")
+        .drop(3)
+        .dropRight(2)
+        .map(_.drop(2)).mkString("\n")
 
     Xor.catchNonFatal(ScalaFormatter.format(wrap(code))) match {
       case Xor.Right(result) ⇒ unwrap(result)

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CommentParsingRenderingSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CommentParsingRenderingSpec.scala
@@ -42,17 +42,17 @@ class CommentParsingRenderingSpec extends FunSpec with Matchers with Inside {
   import CommentZed._
   import Comments.Mode
 
-  val content1 = "This is comment content 1"
-  val content2 = "This is comment content 2"
-  val content3 = "Hello World!!!!!!!"
+  private[this] val content1 = "This is comment content 1"
+  private[this] val content2 = "This is comment content 2"
+  private[this] val content3 = "Hello World!!!!!!!"
 
-  val global = new DocExtractionGlobal() {
+  private[this] val global = new DocExtractionGlobal() {
     locally { new Run() }
   }
 
-  val commentFactory = CommentFactory(global)
+  private[this] val commentFactory = CommentFactory(global)
 
-  def parse(text: String) = commentFactory.parse(text.stripMargin)
+  private[this] def parse(text: String) = commentFactory.parse(text.stripMargin)
 
   object comments {
 

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CommentRenderingRegressions.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CommentRenderingRegressions.scala
@@ -1,0 +1,53 @@
+package com.fortysevendeg.exercises
+package compiler
+
+import org.scalatest._
+
+import cats.data.Xor
+import cats.std.option._
+
+class CommentRenderingRegressions extends refspec.RefSpec with Matchers
+    with Inside {
+  import Comments.Mode
+
+  private[this] val global = new DocExtractionGlobal() {
+    locally { new Run() }
+  }
+
+  private[this] val commentFactory = CommentFactory(global)
+
+  private[this] def parse(text: String) = commentFactory.parse(text.stripMargin)
+
+  object `issues ` {
+    def `github #309` {
+
+      // Summary:
+      // Certain code blocks in comments fail to render.
+      // In this instance, the buggy result was:
+      // <p></p><pre class="scala"><code class="scala"></code></pre>
+
+      val comment = commentFactory.parse(s"""
+        /**
+          * {{{
+          * Functor[List].map(List("qwer", "adsfg"))(_.length)
+          * }}}
+          */""")
+
+      inside(Comments.parseAndRender[Mode.Exercise](comment)) {
+        case Xor.Right(parsed) ⇒
+
+          // remove XML and check that there is code content
+          val description = parsed.description
+            .map(_.replaceAll("\\<.*?\\>", ""))
+            .getOrElse("")
+
+          assert(
+            description.trim.length > 50,
+            "Issue #309: code segment was not properly rendered"
+          )
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
This fixes the formatting bug for certain code blobs in exercise comments. It should close #309.