### PR TITLE
Fix wrong parameter of "psql" when creating the db

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Create a db called `scalaexercises_dev` and grant all privileges on it to `scala
 
 ```sh
 $ createdb scalaexercises_dev
-$ psql -C "GRANT ALL PRIVILEGES ON DATABASE scalaexercises_dev TO scalaexercises_dev_user;"
+$ psql -c "GRANT ALL PRIVILEGES ON DATABASE scalaexercises_dev TO scalaexercises_dev_user;"
 ```
 
 Edit the `site/server/conf/application.dev.conf` configuration file with your database information.


### PR DESCRIPTION
From the documentation, the parameter for running a command is "-c", not "-C" (http://www.postgresql.org/docs/9.4/static/app-psql.html)