### PR TITLE
Implement Evaluator based on Scala Compiler

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -38,11 +38,18 @@ lazy val compiler = (project in file("compiler"))
   .dependsOn(runtime % "test")
 
 // ~ Exercise Runtime
-lazy val runtime = (project in file("runtime"))
+lazy val `runtime-example` = project
   .settings(
-    name            := "runtime"
+    name := "runtime-example"
   )
+  .settings(libraryDependencies += Dep.cats.core)
+
+lazy val runtime = (project in file("runtime"))
   .settings(commonSettings: _*)
+  .settings(
+    name := "runtime"
+  )
+  .dependsOn(`runtime-example` % "test")
   .settings(libraryDependencies <++= scalaVersion(scalaVersion =>
     compilelibs(
       Dep.scala.compiler(scalaVersion),

--- a/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
+++ b/core/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
@@ -21,7 +21,8 @@ case class TreeGen[U <: Universe](
     name: String, description: Option[String],
     code: String, qualifiedMethod: String,
     imports:     List[String],
-    explanation: Option[String]
+    explanation: Option[String],
+    packageName: String
   ) = {
     val term = makeTermName("Exercise", name)
     term → q"""
@@ -29,6 +30,7 @@ case class TreeGen[U <: Universe](
           override val name             = $name
           override val description      = $description
           override val code             = $code
+          override val packageName      = $packageName
           override val qualifiedMethod  = $qualifiedMethod
           override val imports          = $imports
           override val explanation      = $explanation

--- a/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
+++ b/core/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
@@ -21,6 +21,7 @@ class TreeGenSpec extends FunSpec with Matchers {
           name = "Example1",
           description = None,
           code = "code",
+          packageName = "foo",
           qualifiedMethod = "foo.bar",
           imports = Nil,
           explanation = None
@@ -29,6 +30,7 @@ class TreeGenSpec extends FunSpec with Matchers {
           name = "Example2",
           description = None,
           code = "code",
+          packageName = "foo",
           qualifiedMethod = "foo.bar",
           imports = Nil,
           explanation = None

--- a/core/runtime-example/src/main/scala/com.fortysevendeg.exercises/Example.scala
+++ b/core/runtime-example/src/main/scala/com.fortysevendeg.exercises/Example.scala
@@ -1,0 +1,15 @@
+package com.fortysevendeg.exercises
+
+object ExampleTarget {
+  def intStringMethod(a: Int, b: String): String = {
+    s"$a$b"
+  }
+
+  class ExampleException extends Exception("this is an example exception")
+
+  def throwsExceptionMethod() {
+    throw new ExampleException
+  }
+
+  def takesXorMethod(xor: cats.data.Xor[_, _]): Boolean = true
+}

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/Evaluator.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/Evaluator.scala
@@ -1,0 +1,255 @@
+/*
+ * scala-exercises-runtime
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+package com.fortysevendeg.exercises
+
+import java.io.File
+import java.nio.file.Path
+import java.util.jar.JarFile
+import scala.tools.nsc.Settings
+
+import scala.tools.nsc.{ Global, Settings }
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.io.{ VirtualDirectory, AbstractFile }
+import scala.reflect.internal.util.{ NoPosition, BatchSourceFile, AbstractFileClassLoader }
+
+import java.io.File
+import java.nio.file.Path
+import java.net.{ URL, URLClassLoader }
+import java.util.concurrent.{ TimeoutException, Callable, FutureTask, TimeUnit }
+
+import scala.util.Try
+import scala.util.control.NonFatal
+import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+
+sealed trait Severity
+final case object Info extends Severity
+final case object Warning extends Severity
+final case object Error extends Severity
+
+case class RangePosition(start: Int, point: Int, end: Int)
+case class CompilationInfo(message: String, pos: Option[RangePosition])
+case class RuntimeError(val error: Throwable, position: Option[Int])
+
+sealed trait EvalResult[+T]
+object EvalResult {
+  type CI = Map[Severity, List[CompilationInfo]]
+
+  case object Timeout extends EvalResult[Nothing]
+  case class Success[T](complilationInfos: CI, result: T, consoleOutput: String) extends EvalResult[T]
+  case class EvalRuntimeError(complilationInfos: CI, runtimeError: Option[RuntimeError]) extends EvalResult[Nothing]
+  case class CompilationError(complilationInfos: CI) extends EvalResult[Nothing]
+  case class GeneralError(stack: Throwable) extends EvalResult[Nothing]
+}
+
+class Evaluator(timeout: Duration = 20.seconds) {
+  val security = false
+
+  private def classPathOfClass(className: String) = {
+    val resource = className.split('.').mkString("/", "/", ".class")
+    val path = getClass.getResource(resource).getPath
+    if (path.indexOf("file:") >= 0) {
+      val indexOfFile = path.indexOf("file:") + 5
+      val indexOfSeparator = path.lastIndexOf('!')
+      List(path.substring(indexOfFile, indexOfSeparator))
+    } else {
+      require(path.endsWith(resource))
+      List(path.substring(0, path.length - resource.length + 1))
+    }
+  }
+
+  private val compilerPath = try {
+    classPathOfClass("scala.tools.nsc.Interpreter")
+  } catch {
+    case e: Throwable ⇒
+      throw new RuntimeException("Unable to load Scala interpreter from classpath (scala-compiler jar is missing?)", e)
+  }
+
+  private val libPath = try {
+    classPathOfClass("scala.AnyVal")
+  } catch {
+    case e: Throwable ⇒
+      throw new RuntimeException("Unable to load scala base object from classpath (scala-library jar is missing?)", e)
+  }
+
+  private val impliedClassPath: List[String] = {
+    def getClassPath(cl: ClassLoader, acc: List[List[String]] = List.empty): List[List[String]] = {
+      val cp = cl match {
+        case urlClassLoader: URLClassLoader ⇒ urlClassLoader.getURLs.filter(_.getProtocol == "file").
+          map(u ⇒ new File(u.toURI).getPath).toList
+        case _ ⇒ Nil
+      }
+      cl.getParent match {
+        case null   ⇒ (cp :: acc).reverse
+        case parent ⇒ getClassPath(parent, cp :: acc)
+      }
+    }
+
+    val classPath = getClassPath(this.getClass.getClassLoader)
+    val currentClassPath = classPath.head
+
+    // if there's just one thing in the classpath, and it's a jar, assume an executable jar.
+    currentClassPath ::: (if (currentClassPath.size == 1 && currentClassPath(0).endsWith(".jar")) {
+      val jarFile = currentClassPath(0)
+      val relativeRoot = new File(jarFile).getParentFile()
+      val nestedClassPath = new JarFile(jarFile).getManifest.getMainAttributes.getValue("Class-Path")
+      if (nestedClassPath eq null) {
+        Nil
+      } else {
+        nestedClassPath.split(" ").map { f ⇒ new File(relativeRoot, f).getAbsolutePath }.toList
+      }
+    } else {
+      Nil
+    }) ::: classPath.tail.flatten
+  }
+
+  def apply[T](pre: String, code: String): EvalResult[T] = {
+    try { runTimeout[T](pre, code) }
+    catch { case NonFatal(e) ⇒ EvalResult.GeneralError(e) }
+  }
+
+  private def runTimeout[T](pre: String, code: String) =
+    withTimeout { eval[T](pre, code) }(timeout).getOrElse(EvalResult.Timeout)
+
+  private def eval[T](pre: String, code: String): EvalResult[T] = {
+    val className = "Eval" + Math.abs(scala.util.Random.nextLong).toString
+    val wrapedCode =
+      s"""|$pre
+          |class $className extends (() ⇒ Any) {
+          |  def apply() = $code
+          |}""".stripMargin
+
+    secured { compile(wrapedCode) }
+
+    val complilationInfos = check()
+    if (!complilationInfos.contains(Error)) {
+      try {
+        val (result, consoleOutput) = run[T](className)
+        EvalResult.Success(complilationInfos, result, consoleOutput)
+      } catch { case NonFatal(e) ⇒ EvalResult.EvalRuntimeError(complilationInfos, handleException(e)) }
+    } else {
+      EvalResult.CompilationError(complilationInfos)
+    }
+  }
+
+  private def run[T](className: String) = {
+    val cl = Class.forName(className, false, classLoader)
+    val cons = cl.getConstructor()
+    secured {
+      val baos = new java.io.ByteArrayOutputStream()
+      val ps = new java.io.PrintStream(baos)
+      val result = Console.withOut(ps)(cons.newInstance().asInstanceOf[() ⇒ Any].apply().asInstanceOf[T])
+      (result, baos.toString("UTF-8"))
+    }
+  }
+
+  private def withTimeout[T](f: ⇒ T)(timeout: Duration): Option[T] = {
+    val task = new FutureTask(new Callable[T]() { def call = f })
+    val thread = new Thread(task)
+    try {
+      thread.start()
+      Some(task.get(timeout.toMillis, TimeUnit.MILLISECONDS))
+    } catch {
+      case e: TimeoutException ⇒ None
+    } finally {
+      if (thread.isAlive) thread.stop()
+    }
+  }
+
+  private def handleException(e: Throwable): Option[RuntimeError] = {
+    def search(e: Throwable) = {
+      e.getStackTrace.find(_.getFileName == "(inline)").map(v ⇒
+        (e, Some(v.getLineNumber)))
+    }
+    def loop(e: Throwable): Option[(Throwable, Option[Int])] = {
+      val s = search(e)
+      if (s.isEmpty)
+        if (e.getCause != null) loop(e.getCause)
+        else Some((e, None))
+      else s
+    }
+    loop(e).map {
+      case (err, line) ⇒
+        RuntimeError(err, line)
+    }
+  }
+
+  private def check(): Map[Severity, List[CompilationInfo]] = {
+    val infos =
+      reporter.infos.map { info ⇒
+        val pos = info.pos match {
+          case NoPosition ⇒ None
+          case _          ⇒ Some(RangePosition(info.pos.start, info.pos.point, info.pos.end))
+        }
+        (
+          info.severity,
+          info.msg,
+          pos
+        )
+      }.to[List]
+        .groupBy(_._1)
+        .mapValues { _.map { case (_, msg, pos) ⇒ (msg, pos) } }
+
+    def convert(infos: Map[reporter.Severity, List[(String, Option[RangePosition])]]): Map[Severity, List[CompilationInfo]] = {
+      infos.map {
+        case (k, vs) ⇒
+          val sev = k match {
+            case reporter.ERROR   ⇒ Error
+            case reporter.WARNING ⇒ Warning
+            case reporter.INFO    ⇒ Info
+          }
+          val info = vs map {
+            case (msg, pos) ⇒
+              CompilationInfo(msg, pos)
+          }
+          (sev, info)
+      }
+    }
+    convert(infos)
+  }
+
+  private def reset(): Unit = {
+    target.clear()
+    reporter.reset()
+    classLoader = new AbstractFileClassLoader(target, artifactLoader)
+  }
+
+  private def compile(code: String): Unit = {
+    reset()
+    val run = new compiler.Run
+    val sourceFiles = List(new BatchSourceFile("(inline)", code))
+    run.compileSources(sourceFiles)
+  }
+
+  private val reporter = new StoreReporter()
+
+  val settings = new Settings()
+  settings.processArguments(List(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-unchecked"
+  ), true)
+  val classpath = (compilerPath ::: libPath ::: impliedClassPath).mkString(File.pathSeparator)
+  settings.bootclasspath.value = classpath
+  settings.classpath.value = classpath
+
+  private val artifactLoader = {
+    val loaderFiles =
+      settings.classpath.value.split(File.pathSeparator).map(a ⇒ {
+        val node = new java.io.File(a)
+        val endSlashed =
+          if (node.isDirectory) node.toString + File.separator
+          else node.toString
+
+        new File(endSlashed).toURI().toURL
+      })
+    new URLClassLoader(loaderFiles, this.getClass.getClassLoader)
+  }
+  private val target = new VirtualDirectory("(memory)", None)
+  settings.outputDirs.setSingleOutput(target)
+  private var classLoader: AbstractFileClassLoader = _
+  private val compiler = new Global(settings, reporter)
+  private val secured = new Secured(security)
+}

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/MethodEval.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/MethodEval.scala
@@ -4,18 +4,9 @@
  */
 
 package com.fortysevendeg.exercises
-
-import scala.language.experimental.macros
-
-import java.lang.reflect.InvocationTargetException
-import scala.reflect.runtime.{ universe ⇒ ru }
-import scala.reflect.runtime.{ currentMirror ⇒ cm }
-import scala.tools.reflect.ToolBox
-
 import cats.data.{ Ior, Xor }
-import cats.std.list._
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
+import java.nio.file.Path
+import scala.concurrent.duration._
 
 object MethodEval {
 
@@ -67,92 +58,42 @@ object MethodEval {
   case class EvaluationSuccess[A](res: A) extends EvaluationResult[A](true)
 }
 
-class MethodEval {
+class MethodEval() {
   import MethodEval._
+  import EvalResult._
 
-  private[this] val toolbox = cm.mkToolBox()
-  private[this] val mirror = ru.runtimeMirror(classOf[MethodEval].getClassLoader)
-  import mirror.universe._
+  val timeout = 20.seconds
+  private val evaluator = new Evaluator(timeout)
 
-  private[this]type Res[A] = Xor[Ior[String, Throwable], A]
+  def eval[T](qualifiedMethod: String, rawArgs: List[String], imports: List[String] = Nil): EvaluationResult[_] = {
+    val pre = imports.mkString(System.lineSeparator)
+    val code = s"""$qualifiedMethod(${rawArgs.mkString(", ")})"""
 
-  private[this] def error[A](message: String): Res[A] = Xor.left(Ior.left(message))
-  private[this] def error[A](e: Throwable): Res[A] = Xor.left(Ior.right(e))
-  private[this] def error[A](message: String, e: Throwable): Res[A] = Xor.left(Ior.both(message, e))
-  private[this] def success[A](value: A): Res[A] = Xor.right(value)
-
-  private[this] def catching[A](f: ⇒ A): Res[A] = Xor.catchNonFatal(f).leftMap(e ⇒ Ior.right(e))
-  private[this] def catching[A](f: ⇒ A, message: ⇒ String): Res[A] = Xor.catchNonFatal(f).leftMap(e ⇒ Ior.both(message, e))
-
-
-  // format: OFF
-  def eval(qualifiedMethod: String, rawArgs: List[String], imports: List[String] = Nil): EvaluationResult[_] = {
-    val result = for {
-
-    lastIndex ← {
-      val lastIndex = qualifiedMethod.lastIndexOf('.')
-      if (lastIndex > 0) success(lastIndex)
-      else error(s"Invalid qualified method $qualifiedMethod")
-    }
-    moduleName = qualifiedMethod.substring(0, lastIndex)
-    methodName = qualifiedMethod.substring(lastIndex + 1)
-
-    staticModule ← catching(mirror.staticModule(moduleName),
-      s"Unable to load module $moduleName")
-
-    moduleMirror ← catching(mirror.reflectModule(staticModule),
-      s"Unable to reflect module mirror for $moduleName")
-
-    instanceMirror ← catching(mirror.reflect(moduleMirror.instance),
-      s"Unable to reflect instance mirror for $moduleName")
-
-    methodSymbol ← catching(instanceMirror.symbol.typeSignature.decl(TermName(methodName)).asMethod,
-      s"Unable to get type for module $moduleName")
-
-    argTypes ← methodSymbol.paramLists match {
-      case singleGroup :: Nil ⇒ success(singleGroup.map(_.typeSignature))
-      case _                  ⇒ error(s"Expected just one argument group on method $qualifiedMethod")
+    def convert(runtimeError: Option[RuntimeError]): Throwable = {
+      val unknown = new Exception("unknown error")
+      runtimeError.map(_.error).getOrElse(unknown)
     }
 
+    // * propagate as much information as possible to the ui
+    // * the user provide rawArgs and is wraped inside a class, you want to shift error position
+    evaluator[T](pre, code) match {
 
-    importer0 = ru.mkImporter(mirror.universe)
-    importer = importer0.asInstanceOf[ru.Importer { val from: mirror.universe.type }]
+      case Success(complilationInfos, result, consoleOutput) ⇒
+        EvaluationSuccess(result)
 
-    args ← (rawArgs zip argTypes).map { case (arg, tpe) ⇒
-        for {
-          parsedArg ← catching(toolbox.parse(arg),
-            s"Unable to parse arg $arg")
+      case EvalRuntimeError(complilationInfos, runtimeError) ⇒
+        EvaluationException(convert(runtimeError))
 
-          parsedImports ← imports.map(imp ⇒ catching(toolbox.parse(imp),
-            s"Unable to parse import '$imp'")).sequenceU
-
-          tree = q"""
-            ..$parsedImports
-            $parsedArg: $tpe
-          """
-
-          evaledArg ← catching(toolbox.eval(tree),
-              s"Unable to evaluate arg $arg as $tpe")
-
-        } yield evaledArg
-
-      }.sequenceU
-
-    result ←
-      try {
-        success(EvaluationSuccess(instanceMirror.reflectMethod(methodSymbol)(args: _*)))
-      } catch {
-        // capture exceptions thrown by the method, since they are considered success
-        case e: InvocationTargetException ⇒ success(EvaluationException(e.getCause))
-        case scala.util.control.NonFatal(t) ⇒ error(t)
+      case CompilationError(complilationInfos) ⇒ {
+        val messages = complilationInfos.values.flatMap(_.map(_.message)).mkString(", ")
+        EvaluationFailure(Ior.left(s"compilation error $messages"))
       }
-  } yield result
 
-  result.fold(
-    EvaluationFailure(_),
-    identity
-  )
-}
+      case GeneralError(stack) ⇒
+        EvaluationFailure(Ior.both("global error", stack))
 
-  // format: ON
+      case Timeout ⇒
+        EvaluationFailure(Ior.left(s"compilation timed out after $timeout"))
+    }
+  }
 }

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/MethodEval.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/MethodEval.scala
@@ -65,8 +65,8 @@ class MethodEval() {
   val timeout = 20.seconds
   private val evaluator = new Evaluator(timeout)
 
-  def eval[T](qualifiedMethod: String, rawArgs: List[String], imports: List[String] = Nil): EvaluationResult[_] = {
-    val pre = imports.mkString(System.lineSeparator)
+  def eval[T](pkg: String, qualifiedMethod: String, rawArgs: List[String], imports: List[String] = Nil): EvaluationResult[_] = {
+    val pre = (s"import $pkg._" :: imports).mkString(System.lineSeparator)
     val code = s"""$qualifiedMethod(${rawArgs.mkString(", ")})"""
 
     def convert(runtimeError: Option[RuntimeError]): Throwable = {

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/Security.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/Security.scala
@@ -1,0 +1,26 @@
+package com.fortysevendeg.exercises
+
+import java.security._
+
+class Secured(security: Boolean) {
+  private var started = false
+
+  class ScalaExercicesSecurityPolicy extends Policy {
+    val read1 = new java.io.FilePermission("../-", "read")
+    val read2 = new java.io.FilePermission("../.", "read")
+    val other = new java.net.NetPermission("specifyStreamHandler")
+
+    override def implies(domain: ProtectionDomain, permission: Permission) = {
+      List(read1, read2, other).exists(_.implies(permission)) ||
+        Thread.currentThread().getStackTrace().find(_.getFileName == "(inline)").isEmpty
+    }
+  }
+  def apply[T](f: ⇒ T): T = {
+    if (!started && security) {
+      started = true
+      Policy.setPolicy(new ScalaExercicesSecurityPolicy)
+      System.setSecurityManager(new SecurityManager)
+    }
+    f
+  }
+}

--- a/core/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
+++ b/core/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
@@ -32,6 +32,7 @@ trait Exercise {
   def description: Option[String]
   def code: String
   def qualifiedMethod: String
+  def packageName: String
   def imports: List[String]
   def explanation: Option[String]
 }
@@ -57,5 +58,6 @@ case class DefaultExercise(
   code:            String,
   qualifiedMethod: String,
   imports:         List[String],
-  explanation:     Option[String] = None
+  explanation:     Option[String] = None,
+  packageName:     String
 ) extends Exercise

--- a/core/runtime/src/test/scala/com/fortysevendeg/exercises/MethodEvalSpec.scala
+++ b/core/runtime/src/test/scala/com/fortysevendeg/exercises/MethodEvalSpec.scala
@@ -16,6 +16,7 @@ class MethodEvalSpec extends FunSpec with Matchers {
 
     it("fails when incorrect parameter types are provided") {
       val res = methodEval.eval(
+        "com.fortysevendeg.exercises",
         "com.fortysevendeg.exercises.ExampleTarget.intStringMethod",
         "\"hello\"" :: "\"world\"" :: Nil
       )
@@ -26,6 +27,7 @@ class MethodEvalSpec extends FunSpec with Matchers {
 
     it("fails when too many parameters are provided") {
       val res = methodEval.eval(
+        "com.fortysevendeg.exercises",
         "com.fortysevendeg.exercises.ExampleTarget.intStringMethod",
         "\"hello\"" :: "\"world\"" :: "1" :: Nil
       )
@@ -36,6 +38,7 @@ class MethodEvalSpec extends FunSpec with Matchers {
 
     it("works when the parameters are appropriate") {
       val res = methodEval.eval(
+        "com.fortysevendeg.exercises",
         "com.fortysevendeg.exercises.ExampleTarget.intStringMethod",
         "1 + 2" :: "\"world\"" :: Nil
       )
@@ -47,6 +50,7 @@ class MethodEvalSpec extends FunSpec with Matchers {
 
     it("captures exceptions thrown by the called method") {
       val res = methodEval.eval(
+        "com.fortysevendeg.exercises",
         "com.fortysevendeg.exercises.ExampleTarget.throwsExceptionMethod",
         Nil
       )
@@ -60,6 +64,7 @@ class MethodEvalSpec extends FunSpec with Matchers {
 
     it("interprets imports properly") {
       val res = methodEval.eval(
+        "com.fortysevendeg.exercises",
         "com.fortysevendeg.exercises.ExampleTarget.takesXorMethod",
         "Xor.right(1)" :: Nil,
         "import cats.data.Xor" :: Nil

--- a/core/runtime/src/test/scala/com/fortysevendeg/exercises/MethodEvalSpec.scala
+++ b/core/runtime/src/test/scala/com/fortysevendeg/exercises/MethodEvalSpec.scala
@@ -6,12 +6,9 @@
 package com.fortysevendeg.exercises
 
 import org.scalatest._
-
-import cats.data.Xor
+import MethodEval._
 
 class MethodEvalSpec extends FunSpec with Matchers {
-
-  import MethodEval._
 
   describe("runtime evaluation") {
 
@@ -74,18 +71,4 @@ class MethodEvalSpec extends FunSpec with Matchers {
     }
 
   }
-}
-
-object ExampleTarget {
-  def intStringMethod(a: Int, b: String): String = {
-    s"$a$b"
-  }
-
-  class ExampleException extends Exception("this is an example exception")
-
-  def throwsExceptionMethod() {
-    throw new ExampleException
-  }
-
-  def takesXorMethod(xor: Xor[_, _]): Boolean = true
 }

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/check/src/main/scala/check.scala
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/check/src/main/scala/check.scala
@@ -18,7 +18,11 @@ object Check extends App {
     .flatMap(_.sections.find(_.name == "foo"))
     .flatMap(_.exercises.find(_.name == "foo1"))
     .flatMap(exercise => {
-      methodEval.eval(exercise.qualifiedMethod, "\"arg!\"" :: Nil, Nil)
+      methodEval.eval(
+        "stdlib",
+        exercise.qualifiedMethod,
+        "\"arg!\"" :: Nil,
+        Nil)
         .toSuccessXor.toOption.map(x => x.res.asInstanceOf[String])
     })
 

--- a/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/check/src/main/scala/check.scala
+++ b/core/sbt-exercise/src/sbt-test/sbt-exercise/basic/check/src/main/scala/check.scala
@@ -1,5 +1,6 @@
-import com.fortysevendeg.exercises.Exercises
-import com.fortysevendeg.exercises.MethodEval
+import com.fortysevendeg.exercises._
+
+import java.nio.file.Paths
 
 object Check extends App {
 
@@ -16,11 +17,10 @@ object Check extends App {
   val res = libraries.find(_.name == "sample")
     .flatMap(_.sections.find(_.name == "foo"))
     .flatMap(_.exercises.find(_.name == "foo1"))
-    .flatMap(exercise =>
-      methodEval
-        .eval(exercise.qualifiedMethod,
-          "\"arg!\"" :: Nil, Nil)
-        .toSuccessXor.toOption.map(_.res.asInstanceOf[String]))
+    .flatMap(exercise => {
+      methodEval.eval(exercise.qualifiedMethod, "\"arg!\"" :: Nil, Nil)
+        .toSuccessXor.toOption.map(x => x.res.asInstanceOf[String])
+    })
 
   assert(res.isDefined, "evaluation of exercise method failed")
 }

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -27,11 +27,10 @@ lazy val commonSettings = Seq(
 lazy val clients = Seq(client)
 lazy val doobieVersion = "0.2.3"
 lazy val scalazVersion = "7.1.4"
+
 lazy val server = (project in file("server"))
   .aggregate(clients.map(projectToRef): _*)
-  .dependsOn(
-    sharedJvm,
-    content)
+  .dependsOn(sharedJvm, content)
   .dependsOn(ProjectRef(file("../core"), "runtime"))
   .enablePlugins(PlayScala)
   .settings(commonSettings: _*)

--- a/site/project/plugins.sbt
+++ b/site/project/plugins.sbt
@@ -22,6 +22,8 @@ addSbtPlugin("default" % "sbt-sass" % "0.1.9")
 
 addSbtPlugin("com.heroku" % "sbt-heroku" % "0.5.4")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+
 // Build common plugin
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
 addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")

--- a/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -3,16 +3,15 @@
  * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
  */
 
-package com.fortysevendeg.exercises.services
+package com.fortysevendeg.exercises
+package services
 
 import com.fortysevendeg.exercises.Exercises
 import com.fortysevendeg.exercises.MethodEval
 
 import play.api.Logger
 
-import scala.reflect.runtime.{ universe ⇒ ru }
-import scala.reflect.runtime.{ currentMirror ⇒ cm }
-import scala.tools.reflect.ToolBox
+import java.nio.file.Paths
 
 import cats.data.Xor
 import cats.data.Ior
@@ -25,7 +24,7 @@ import org.scalatest.exceptions.TestFailedException
 object ExercisesService extends RuntimeSharedConversions {
   import MethodEval._
 
-  lazy val methodEval = new MethodEval()
+  val methodEval = new MethodEval()
 
   val (errors, runtimeLibraries) = Exercises.discoverLibraries(cl = ExercisesService.getClass.getClassLoader)
   val (libraries, librarySections) = {

--- a/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/site/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -49,8 +49,9 @@ object ExercisesService extends RuntimeSharedConversions {
       case e                      ⇒ s"Runtime error: ${e.getMessage}"
     }
 
-    def eval(imports: List[String]) = {
+    def eval(pkg: String, imports: List[String]) = {
       val res = methodEval.eval(
+        pkg,
         evaluation.method,
         evaluation.args,
         imports
@@ -74,9 +75,9 @@ object ExercisesService extends RuntimeSharedConversions {
       runtimeExercise ← runtimeSection.exercises.find(_.qualifiedMethod == evaluation.method)
         .toRightXor(s"Unable to find exercise for method ${evaluation.method}")
 
-    } yield runtimeExercise.imports
+    } yield (runtimeExercise.packageName, runtimeExercise.imports)
 
-    val res = imports >>= eval
+    val res = imports >>= (eval _).tupled
     Logger.info(s"evaluation for $evaluation: $res")
     res
 


### PR DESCRIPTION
* Evaluator produce an EvalResult[T] it has more information than the original EvaluationResult[T]
  double check to see what can be bubble back to the ui
    * RangePosition in CompilationInfo would need to be shifted (see wrapedCode in eval[T])
* I'm using sbt BuildInfo in ExerciceService to find the correct classpath (artifacts). This would changed when deployed.
  I'm not too familiar with Play dependency injection, it's up to you guys to figure it out.
* MethodEval security (jvm SecurityManager) is off by default in ExercisesService. Play and sbt are running on the same jvm. It should work fine when deployed.