### PR TITLE
Add Andy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,14 +269,14 @@ lazy val publishSettings = Seq(
           <email>al.g.g@47deg.com</email>
         </developer>
         <developer>
-          <id>rafaparadela</id>
-          <name>Rafa Paradela</name>
-          <email>rafa.p@47deg.com</email>
-        </developer>
-        <developer>
           <id>MasseGuillaume</id>
           <name>Guillaume Massé</name>
           <email>masgui@gmail.com</email>
+        </developer>
+        <developer>
+          <id>rafaparadela</id>
+          <name>Rafa Paradela</name>
+          <email>rafa.p@47deg.com</email>
         </developer>
         <developer>
           <id>raulraja</id>

--- a/build.sbt
+++ b/build.sbt
@@ -259,9 +259,9 @@ lazy val publishSettings = Seq(
   pomExtra :=
       <developers>
         <developer>
-          <id>raulraja</id>
-          <name>Raul Raja</name>
-          <email>raul@47deg.com</email>
+          <id>andyscott</id>
+          <name>Andy Scott</name>
+          <email>andy.s@47deg.com</email>
         </developer>
         <developer>
           <id>dialelo</id>
@@ -277,6 +277,11 @@ lazy val publishSettings = Seq(
           <id>MasseGuillaume</id>
           <name>Guillaume Massé</name>
           <email>masgui@gmail.com</email>
+        </developer>
+        <developer>
+          <id>raulraja</id>
+          <name>Raul Raja</name>
+          <email>raul@47deg.com</email>
         </developer>
       </developers>
 )


### PR DESCRIPTION
When the list of developers was added @andyscott was left out. 
This an undeniably an oversight since Andy is entirely the author of the Exercise compiler.
It also orders the list alphabetically in order to not imply any hierarchy in the importance of contributions.

Apologies @andyscott 

@rafaparadela can you please review?