### PR TITLE
Uniquify generated exercise and section names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ bin/
 
 # OSX
 .DS_Store
+
+# PGP keys
+*.gpg

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val formattingSettings = SbtScalariform.scalariformSettings ++ Seq(
 
 lazy val commonSettings = Seq(
   organization := "org.scala-exercises",
-  version := "0.0.0-SNAPSHOT",
+  version := "0.1.0",
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding",
@@ -81,10 +81,9 @@ lazy val server = (project in file("server"))
       evolutions,
       cache,
     ws,
-      "org.scala-exercises" %% "runtime" % "0.0.0-SNAPSHOT" changing(),
-      "org.scala-exercises" %% "exercises-stdlib" % "0.0.0-SNAPSHOT",
-      "org.scala-exercises" %% "exercises-cats" % "0.0.0-SNAPSHOT",
-      "org.scala-exercises" %% "exercises-shapeless" % "0.0.0-SNAPSHOT",
+      "org.scala-exercises" %% "exercises-stdlib" % "0.1.+" changing(),
+      "org.scala-exercises" %% "exercises-cats" % "0.1.+" changing(),
+      "org.scala-exercises" %% "exercises-shapeless" % "0.1.+" changing(),
       "org.slf4j" % "slf4j-nop" % "1.6.4",
       "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
       "com.vmunier" %% "play-scalajs-scripts" % "0.2.1",
@@ -107,7 +106,7 @@ lazy val server = (project in file("server"))
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1" % "test",
       "org.tpolecat" %% "doobie-contrib-specs2" % doobieVersion % "test",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")))
-
+  .dependsOn(runtime)
 
 lazy val client = (project in file("client"))
   .dependsOn(sharedJs)
@@ -187,14 +186,12 @@ lazy val compiler = (project in file("compiler"))
     libraryDependencies ++= Seq(
       "org.scalariform" %% "scalariform" % "0.1.8",
       "com.fortysevendeg" %% "github4s" % "0.4-SNAPSHOT",
-      "org.scala-exercises" %% "runtime" % "0.0.0-SNAPSHOT" changing(),
-      "org.scala-exercises" %% "definitions" % "0.0.0-SNAPSHOT" changing(),
       "org.typelevel" %% "cats-core" % "0.4.1" % "compile",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "compile",
       "org.typelevel" %% "cats-laws" % "0.4.1" % "test",
       "org.scalatest" %% "scalatest" % "2.2.4" % "test"
     )
- )
+ ).dependsOn(definitions, runtime)
 
 lazy val `sbt-exercise` = (project in file("sbt-exercise"))
   .settings(commonSettings:_*)

--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
@@ -218,6 +218,7 @@ case class Compiler() {
           val (exerciseTerms, exerciseTrees) =
             sectionInfo.exercises.map { exerciseInfo ⇒
               treeGen.makeExercise(
+                libraryName = libraryInfo.comment.name,
                 name = internal.unapplyRawName(exerciseInfo.symbol.name),
                 description = exerciseInfo.comment.description,
                 code = exerciseInfo.code,
@@ -243,6 +244,7 @@ case class Compiler() {
 
           val (sectionTerm, sectionTree) =
             treeGen.makeSection(
+              libraryName = libraryInfo.comment.name,
               name = sectionInfo.comment.name,
               description = sectionInfo.comment.description,
               exerciseTerms = exerciseTerms,

--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
@@ -20,13 +20,16 @@ case class TreeGen[U <: Universe](
   import u._
 
   def makeExercise(
-    name: String, description: Option[String],
-    code: String, qualifiedMethod: String,
-    imports: List[String],
-    explanation: Option[String],
-    packageName: String
+    libraryName:     String,
+    name:            String,
+    description:     Option[String],
+    code:            String,
+    qualifiedMethod: String,
+    imports:         List[String],
+    explanation:     Option[String],
+    packageName:     String
   ) = {
-    val term = makeTermName("Exercise", name)
+    val term = makeTermName(s"Exercise_${libraryName}_", name)
     term → q"""
         object $term extends Exercise {
           override val name             = $name
@@ -40,16 +43,16 @@ case class TreeGen[U <: Universe](
   }
 
   def makeContribution(
-    sha: String,
-    message: String,
+    sha:       String,
+    message:   String,
     timestamp: String,
-    url: String,
-    author: String,
+    url:       String,
+    author:    String,
     authorUrl: String,
     avatarUrl: String
   ) = {
     val term = makeTermName("Contribution", sha)
-    term -> q"""
+    term → q"""
     object $term extends Contribution {
       override def sha = $sha
       override def message = $message
@@ -63,13 +66,15 @@ case class TreeGen[U <: Universe](
   }
 
   def makeSection(
-    name: String, description: Option[String],
-    exerciseTerms: List[TermName],
-    imports: List[String],
-    path: Option[String] = None,
+    libraryName:       String,
+    name:              String,
+    description:       Option[String],
+    exerciseTerms:     List[TermName],
+    imports:           List[String],
+    path:              Option[String] = None,
     contributionTerms: List[TermName]
   ) = {
-    val term = makeTermName("Section", name)
+    val term = makeTermName(s"Section_${libraryName}_", name)
     term → q"""
         object $term extends Section {
           override val name         = $name
@@ -99,7 +104,7 @@ case class TreeGen[U <: Universe](
 
   def makePackage(
     packageName: String,
-    trees: List[Tree]
+    trees:       List[Tree]
   ) = q"""
         package ${makeRefTree(packageName)} {
           import com.fortysevendeg.exercises.Exercise
@@ -121,7 +126,7 @@ case class TreeGen[U <: Universe](
 
   private def makeRefTree(path: String): RefTree = {
     def go(rem: List[String]): RefTree = rem match {
-      case head :: Nil ⇒ Ident(TermName(head))
+      case head :: Nil  ⇒ Ident(TermName(head))
       case head :: tail ⇒ Select(go(tail), TermName(head))
       case Nil ⇒
         // This situation should never occur, and definitely not during

--- a/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
+++ b/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
@@ -18,6 +18,7 @@ class TreeGenSpec extends FunSpec with Matchers {
 
       val exercises = List(
         treeGen.makeExercise(
+          libraryName = "MyLibrary",
           name = "Example1",
           description = None,
           code = "code",
@@ -27,6 +28,7 @@ class TreeGenSpec extends FunSpec with Matchers {
           explanation = None
         ),
         treeGen.makeExercise(
+          libraryName = "MyLibrary",
           name = "Example2",
           description = None,
           code = "code",
@@ -39,6 +41,7 @@ class TreeGenSpec extends FunSpec with Matchers {
 
       val sections = List(
         treeGen.makeSection(
+          libraryName = "MyLibrary",
           name = "Section 1",
           description = Some("This is section 1"),
           exerciseTerms = exercises.map(_._1),
@@ -46,6 +49,7 @@ class TreeGenSpec extends FunSpec with Matchers {
           contributionTerms = Nil
         ),
         treeGen.makeSection(
+          libraryName = "MyLibrary",
           name = "Section 2",
           description = Some("This is section 2"),
           exerciseTerms = Nil,

--- a/runtime/src/main/scala/com/fortysevendeg/exercises/Exercises.scala
+++ b/runtime/src/main/scala/com/fortysevendeg/exercises/Exercises.scala
@@ -19,7 +19,7 @@ import cats.data.Xor
 import org.clapper.classutil.ClassFinder
 
 object Exercises {
-  val LIBRARIES_PACKAGE = "defaultLib"
+  val LIBRARIES_PACKAGE = "scalaExercisesContent"
 
   private[this] def classMap(cl: ClassLoader) = {
     val files = cl.asInstanceOf[URLClassLoader].getURLs map (_.getFile)

--- a/runtime/src/test/scala/com/fortysevendeg/exercises/Content.scala
+++ b/runtime/src/test/scala/com/fortysevendeg/exercises/Content.scala
@@ -1,4 +1,4 @@
-package defaultLib
+package scalaExercisesContent
 
 import com.fortysevendeg.exercises.Library
 

--- a/runtime/src/test/scala/com/fortysevendeg/exercises/LibraryDiscoverySpec.scala
+++ b/runtime/src/test/scala/com/fortysevendeg/exercises/LibraryDiscoverySpec.scala
@@ -9,7 +9,7 @@ import org.scalatest._
 
 class LibraryDiscoverySpec extends FunSpec with Matchers {
 
-  import defaultLib._
+  import scalaExercisesContent._
 
   val cl = classOf[Exercise].getClassLoader
 

--- a/sbt-exercise/src/main/scala/com/fortysevendeg/exercises/sbtexercise/ExerciseCompilerPlugin.scala
+++ b/sbt-exercise/src/main/scala/com/fortysevendeg/exercises/sbtexercise/ExerciseCompilerPlugin.scala
@@ -179,7 +179,7 @@ object ExerciseCompilerPlugin extends AutoPlugin {
               sources = sourceCodes.map(_._2).toArray,
               paths = sourceCodes.map(_._1).toArray,
               baseDir = baseDir.getPath,
-              targetPackage = "defaultLib"
+              targetPackage = "scalaExercisesContent"
             ).toList
           }
       } leftMap (e ⇒ e: Err) >>= {

--- a/sbt-exercise/src/sbt-test/sbt-exercise/basic/test
+++ b/sbt-exercise/src/sbt-test/sbt-exercise/basic/test
@@ -1,11 +1,11 @@
 # check that the exercise plugin works on a minimal project
 
--$ exists content/target/scala-2.11/src_managed/main/defaultLib/
+-$ exists content/target/scala-2.11/src_managed/main/scalaExercisesContent/
 
 > project content
 > package
 
-$ exists content/target/scala-2.11/src_managed/main/defaultLib/
+$ exists content/target/scala-2.11/src_managed/main/scalaExercisesContent/
 
 > project check
 > run


### PR DESCRIPTION
And change the target package from `defaultLib` for the more semantic
`scalaExercisesContent`. Closes #458