### PR TITLE
Version the content and site together

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,9 +81,10 @@ lazy val server = (project in file("server"))
       evolutions,
       cache,
     ws,
-      "org.scala-exercises" %% "exercises-stdlib" % "0.1.+" changing(),
-      "org.scala-exercises" %% "exercises-cats" % "0.1.+" changing(),
-      "org.scala-exercises" %% "exercises-shapeless" % "0.1.+" changing(),
+      "org.scala-exercises" %% "runtime" % version.value,
+      "org.scala-exercises" %% "exercises-stdlib" % version.value,
+      "org.scala-exercises" %% "exercises-cats" % version.value,
+      "org.scala-exercises" %% "exercises-shapeless" % version.value,
       "org.slf4j" % "slf4j-nop" % "1.6.4",
       "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
       "com.vmunier" %% "play-scalajs-scripts" % "0.2.1",
@@ -106,7 +107,6 @@ lazy val server = (project in file("server"))
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1" % "test",
       "org.tpolecat" %% "doobie-contrib-specs2" % doobieVersion % "test",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")))
-  .dependsOn(runtime)
 
 lazy val client = (project in file("client"))
   .dependsOn(sharedJs)
@@ -186,12 +186,14 @@ lazy val compiler = (project in file("compiler"))
     libraryDependencies ++= Seq(
       "org.scalariform" %% "scalariform" % "0.1.8",
       "com.fortysevendeg" %% "github4s" % "0.5-SNAPSHOT",
+      "org.scala-exercises" %% "definitions" % version.value,
+      "org.scala-exercises" %% "runtime" % version.value,
       "org.typelevel" %% "cats-core" % "0.4.1" % "compile",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "compile",
       "org.typelevel" %% "cats-laws" % "0.4.1" % "test",
       "org.scalatest" %% "scalatest" % "2.2.4" % "test"
     )
- ).dependsOn(definitions, runtime)
+ )
 
 lazy val `sbt-exercise` = (project in file("sbt-exercise"))
   .settings(commonSettings:_*)


### PR DESCRIPTION
For avoiding accidentaly introduced incompatibilities between the
content, runtime and the site I've decided to not continue using wildcard
version specs like 0.1.+. This means that each time we want to publish
the content we'll have to bump the content repos *and* the site, but is
an extra check that can avoid problems introduced by automatic
deployments like in #490