### PR TITLE
Adds setting for not fetching contributions on compilation

### DIFF
--- a/compiler/src/main/scala/org/scalaexercises/exercises/compiler/Compiler.scala
+++ b/compiler/src/main/scala/org/scalaexercises/exercises/compiler/Compiler.scala
@@ -27,8 +27,8 @@ import Comments.Mode
 import CommentRendering.RenderedComment
 
 class CompilerJava {
-  def compile(library: AnyRef, sources: Array[String], paths: Array[String], baseDir: String, targetPackage: String): Array[String] = {
-    Compiler().compile(library.asInstanceOf[Library], sources.toList, paths.toList, baseDir, targetPackage)
+  def compile(library: AnyRef, sources: Array[String], paths: Array[String], baseDir: String, targetPackage: String, fetchContributors: Boolean): Array[String] = {
+    Compiler().compile(library.asInstanceOf[Library], sources.toList, paths.toList, baseDir, targetPackage, fetchContributors)
       .fold(`🍺` ⇒ throw new Exception(`🍺`), out ⇒ Array(out._1, out._2))
   }
 }
@@ -36,7 +36,7 @@ class CompilerJava {
 case class Compiler() {
   lazy val sourceTextExtractor = new SourceTextExtraction()
 
-  def compile(library: Library, sources: List[String], paths: List[String], baseDir: String, targetPackage: String) = {
+  def compile(library: Library, sources: List[String], paths: List[String], baseDir: String, targetPackage: String, fetchContributors: Boolean) = {
     val mirror = ru.runtimeMirror(library.getClass.getClassLoader)
     import mirror.universe._
 
@@ -132,7 +132,7 @@ case class Compiler() {
         comment ← (internal.resolveComment(symbolPath) >>= Comments.parseAndRender[Mode.Section])
           .leftMap(enhanceDocError(symbolPath))
 
-        contributions = filePath.fold(
+        contributions = (if (fetchContributors) filePath else None).fold(
           List.empty[ContributionInfo]
         )(path ⇒ fetchContributions(library.owner, library.repository, path))
 

--- a/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CompilerSpec.scala
+++ b/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CompilerSpec.scala
@@ -53,7 +53,7 @@ class CompilerSpec extends FunSpec with Matchers {
         .asInstanceOf[Library]
 
       val path = "(internal)"
-      val res = Compiler().compile(library, code :: Nil, path :: Nil, "/", "sample")
+      val res = Compiler().compile(library, code :: Nil, path :: Nil, "/", "sample", fetchContributors = false)
       assert(res.isRight, s"""; ${res.fold(identity, _ ⇒ "")}""")
     }
   }

--- a/sbt-exercise/src/main/scala/org/scalaexercises/exercises/sbtexercise/ExerciseCompilerPlugin.scala
+++ b/sbt-exercise/src/main/scala/org/scalaexercises/exercises/sbtexercise/ExerciseCompilerPlugin.scala
@@ -43,6 +43,8 @@ object ExerciseCompilerPlugin extends AutoPlugin {
 
   val generateExercises = TaskKey[List[(String, String)]]("generate-exercises")
 
+  val fetchContributors = SettingKey[Boolean]("fetch-contributors", "Fetch contributors when compiling")
+
   object autoImport {
     def CompileGeneratedExercises = ExerciseCompilerPlugin.CompileGeneratedExercises
   }
@@ -74,7 +76,8 @@ object ExerciseCompilerPlugin extends AutoPlugin {
       ivyConfigurations   :=
         overrideConfigs(CompileGeneratedExercises, CustomCompile)(ivyConfigurations.value),
       classDirectory in CompileGeneratedExercises := (classDirectory in Compile).value,
-      classpathConfiguration in CompileGeneratedExercises := (classpathConfiguration in Compile).value
+      classpathConfiguration in CompileGeneratedExercises := (classpathConfiguration in Compile).value,
+      fetchContributors := true
     )
   // format: ON
 
@@ -123,11 +126,12 @@ object ExerciseCompilerPlugin extends AutoPlugin {
   private val COMPILER_CLASS = "org.scalaexercises.compiler.CompilerJava"
   private type COMPILER = {
     def compile(
-      library:       AnyRef,
-      sources:       Array[String],
-      paths:         Array[String],
-      baseDir:       String,
-      targetPackage: String
+      library:           AnyRef,
+      sources:           Array[String],
+      paths:             Array[String],
+      baseDir:           String,
+      targetPackage:     String,
+      fetchContributors: Boolean
     ): Array[String]
   }
 
@@ -177,7 +181,8 @@ object ExerciseCompilerPlugin extends AutoPlugin {
               sources = sourceCodes.map(_._2).toArray,
               paths = sourceCodes.map(_._1).toArray,
               baseDir = baseDir.getPath,
-              targetPackage = "org.scalaexercises.content"
+              targetPackage = "org.scalaexercises.content",
+              fetchContributors = fetchContributors.value
             ).toList
           }
       } leftMap (e ⇒ e: Err) >>= {
@@ -241,6 +246,7 @@ object ExerciseCompilerPlugin extends AutoPlugin {
   }
 
   /** Output stream that captures an output on a line by line basis.
+    *
     * @param f the function to invoke with each line
     */
   private[this] class LineByLineOutputStream(


### PR DESCRIPTION
This PR fixes #502 by adding a new `SettingKey` for not fetching contributions on compilation

The default value is `true`. You can modify this value in your "exercises" repo:

*In the SBT session*
```bash
> set ExerciseCompilerPlugin.fetchContributors := false
```

*In the `build.sbt`*
```scala
.settings(
  //...
  ExerciseCompilerPlugin.fetchContributors := false
)
```

Please @dialelo @raulraja could you review? Thanks