### PR TITLE
Prevents empty sections list for Library objects

### DIFF
--- a/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CompilerSpec.scala
+++ b/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CompilerSpec.scala
@@ -1,15 +1,11 @@
 package org.scalaexercises.compiler
 
 import org.scalaexercises.definitions.Library
-
-import scala.reflect.internal.util.AbstractFileClassLoader
-import scala.reflect.internal.util.BatchSourceFile
-import scala.tools.nsc.{ Global, Settings }
-import scala.tools.nsc.io.{ VirtualDirectory, AbstractFile }
-
-import java.lang.ClassLoader
-
 import org.scalatest._
+
+import scala.reflect.internal.util.{ AbstractFileClassLoader, BatchSourceFile }
+import scala.tools.nsc.io.VirtualDirectory
+import scala.tools.nsc.{ Global, Settings }
 
 class CompilerSpec extends FunSpec with Matchers {
 
@@ -55,6 +51,29 @@ class CompilerSpec extends FunSpec with Matchers {
       val path = "(internal)"
       val res = Compiler().compile(library, code :: Nil, path :: Nil, "/", "sample", fetchContributors = false)
       assert(res.isRight, s"""; ${res.fold(identity, _ ⇒ "")}""")
+    }
+
+    it("fails if sections list is empty") {
+
+      val code = """
+      /** This is the sample library.
+        * @param name Sample Library
+        */
+      object SampleLibrary extends org.scalaexercises.definitions.Library {
+        override def owner = "scala-exercises"
+        override def repository = "site"
+        override def sections = Nil
+      }"""
+
+      val classLoader = globalUtil.load(code)
+      val library = classLoader
+        .loadClass("SampleLibrary$")
+        .getField("MODULE$").get(null)
+        .asInstanceOf[Library]
+
+      val path = "(internal)"
+      val res = Compiler().compile(library, code :: Nil, path :: Nil, "/", "sample", fetchContributors = false)
+      assert(res.isLeft, s"""; ${res.fold(identity, _ ⇒ "")}""")
     }
   }
 


### PR DESCRIPTION
This pull request adds a new functionality that allows the compiler to check if the sections list of a `Library` object is empty.

If the list is empty, the compiler will throw an error like:

This PR closes #511 

```
Unable to create SampleLibrary: A Library object must contain at least one section
```

@raulraja @dialelo Please review at your convenience. Thanks!