### PR TITLE
JP - Upgrades Evaluator Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,6 @@ Now run `sbt run` and the application index will also display the added exercise
 
 ## Troubleshooting
 
-#### Running locally
-
-Currently there is classloading issue causing no exercise modules to be displayed on the homepage (See [issue #560](https://github.com/scala-exercises/scala-exercises/issues/560)).
-
-This issue is still pending to be fixed. In the meantime, you could do a quick fix locally.
-
-In the ```server``` project configuration in the ```build.sbt```:
-* replace line (~L103) ```.dependsOn(core.jvm, runtime)``` for ```.dependsOn(core.jvm)```
-* and uncommenting this line (~L121)  
-```// "org.scala-exercises" %% "runtime" % version.value changing(),```
-
-Then run ```sbt run``` and now the exercise modules should show up.
-
 #### Additional exercises do not show up in the application
 
 See the [Adding more exercises](#adding-more-exercises) section. Note that currently the `compile` step is required before `publishLocal` for the application to be able to pickup the exercises.

--- a/app.json
+++ b/app.json
@@ -12,6 +12,15 @@
         "JAVA_TOOL_OPTIONS": {
             "required": true
         },
+        "EVALUATOR_AUTH_KEY": {
+            "required": true
+        },
+        "EVALUATOR_READ_TIMEOUT": {
+            "required": true
+        },
+        "EVALUATOR_URL": {
+            "required": true
+        },
 	"EVOLUTIONS_AUTO_APPLY" : "true",
 	"EVOLUTIONS_AUTO_APPLY_DOWNS" : "true"
     },

--- a/build.sbt
+++ b/build.sbt
@@ -110,13 +110,13 @@ lazy val doobieVersion = "0.2.3"
 lazy val scalazVersion = "7.1.4"
 lazy val github4s = "0.6-SNAPSHOT"
 lazy val cats = "0.6.0"
-lazy val evaluatorVersion = "0.0.2-SNAPSHOT"
+lazy val evaluatorVersion = "0.0.3-SNAPSHOT"
 
 // Client and Server projects
 
 lazy val server = (project in file("server"))
   .aggregate(clients.map(projectToRef): _*)
-  .dependsOn(core.jvm, runtime)
+  .dependsOn(core.jvm)
   .enablePlugins(PlayScala)
   .settings(commonSettings: _*)
   .settings(
@@ -134,7 +134,7 @@ lazy val server = (project in file("server"))
       "org.scala-exercises" %% "exercises-stdlib" % version.value changing(),
       "org.scala-exercises" %% "exercises-cats" % version.value changing(),
       "org.scala-exercises" %% "exercises-shapeless" % version.value changing(),
-      // "org.scala-exercises" %% "runtime" % version.value changing(),
+      "org.scala-exercises" %% "runtime" % version.value changing(),
       "org.scala-exercises" %% "evaluator-client" % evaluatorVersion changing(),
       "org.slf4j" % "slf4j-nop" % "1.6.4",
       "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",


### PR DESCRIPTION
This PR:

* Upgrades the Evaluator client to the latest version
* Updates the `build.sbt` file in order to use runtime dependency as artifact dependency, instead of sbt module dependency.
* Removes the `Running locally` troubleshooting section since the issue has been fixed (issue https://github.com/scala-exercises/scala-exercises/issues/560)

Please, @raulraja could you take a look? Thanks!