### PR TITLE
Change resource access from HTTP to HTTPS

### DIFF
--- a/server/public/javascripts/emojify-cdn.js
+++ b/server/public/javascripts/emojify-cdn.js
@@ -38,7 +38,7 @@
     return {
       config: {
         emojify_tag_type: 'img',
-        cdn_host: 'http://www.tortue.me/emoji',
+        cdn_host: 'https://www.tortue.me/emoji',
         emoji_image_extension: 'png',
         emoticons_enabled: true,
         people_enabled: true,


### PR DESCRIPTION
Fixes #467 

This PR modifies a JS script we're using right now to fetch emoji images to add support for HTTP in order to avoid security problems. Right now it seems there are no other conflictive resources being loaded as HTTP. Could you please review, @dialelo? Thanks!! :)

