### PR TITLE
Fixing problems with input fields resize on paste events

### DIFF
--- a/client/src/main/scala/scripts/ExercisesJS.scala
+++ b/client/src/main/scala/scripts/ExercisesJS.scala
@@ -68,6 +68,9 @@ object ExercisesJS extends js.JSApp {
         _ ← onButtonClick((method: String) ⇒ {
           triggerAction(CompileExercise(method))
         })
+        _ ← onInputChange((method: String, arguments: Seq[String]) ⇒ {
+          triggerAction(UpdateExercise(method, arguments))
+        })
       } yield ()
     }
 

--- a/client/src/main/scala/utils/DomHandler.scala
+++ b/client/src/main/scala/utils/DomHandler.scala
@@ -78,8 +78,10 @@ object DomHandler {
   ): Coeval[Unit] = {
     for {
       inputs ← allInputs
-      _ ← inputs.map(input ⇒ attachOnInputChange(input, onchange)).sequence
-      _ ← inputs.map(input ⇒ attachOnInputPaste(input, onchange)).sequence
+      _ ← inputs.map(input ⇒ {
+        attachOnInputChange(input, onchange)
+        attachOnInputPaste(input, onchange)
+      }).sequence
     } yield ()
   }
 
@@ -111,9 +113,10 @@ object DomHandler {
       updateExerciseInput(
         input,
         (info: (String, Seq[String])) ⇒ {
+          val (method, params) = info
           e.keyCode match {
-            case KeyCode.Enter ⇒ onEnterPressed(info._1).value
-            case _             ⇒ onkeyup(info._1, info._2).value
+            case KeyCode.Enter ⇒ onEnterPressed(method).value
+            case _             ⇒ onkeyup(method, params).value
           }
           ()
         }


### PR DESCRIPTION
Fixes #606 

This PR includes code to fix paste events not being correctly handled by the input fields in the exercises. It also replaces the resizing code, as the resulting size wasn't accurate for long texts.

Could you please review, @dialelo @rafaparadela @juanpedromoreno? Thanks! 