### PR TITLE
Upgrades to the latest version of Github4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val server = (project in file("server"))
       "com.tristanhunt"         %% "knockoff"         % v('knockoff),
       "com.newrelic.agent.java" % "newrelic-agent"    % v('newrelic),
       "commons-io"              % "commons-io"        % v('commonsio),
-      "com.47deg"               %% "freestyle"        % "0.1.0",
+      %%("freestyle"),
       %%("github4s"),
       %("slf4j-nop"),
       %%("scalaz-concurrent"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ resolvers ++= Seq(
 )
 
 // Sbt plugins
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.4.21")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.1")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"       % "2.4.8")
 addSbtPlugin("com.vmunier"       % "sbt-web-scalajs"  % "1.0.3")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-gzip"         % "1.0.0")


### PR DESCRIPTION
...  through `sbt-org-policies` plugin.

This change fixes the issue we had yesterday on the index page, in production, when fetching GH info, where users returned by the GH API might be null. Related to https://github.com/47deg/github4s/pull/144 .