### PR TITLE
Fix comment rendering

### DIFF
--- a/compiler/src/main/scala/org/scalaexercises/exercises/compiler/formatting.scala
+++ b/compiler/src/main/scala/org/scalaexercises/exercises/compiler/formatting.scala
@@ -35,7 +35,10 @@ object formatting {
       .split("\n")
       .drop(3)
       .dropRight(2)
-      .map(_.drop(2))
+      .collect {
+        case line if line.startsWith("  ") => line.drop(2)
+        case line                          => line
+      }
       .mkString("\n")
 
   def formatCode(code: String): String = {

--- a/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CommentRenderingRegressions.scala
+++ b/compiler/src/test/scala/org/scalaexercises/exercises/compiler/CommentRenderingRegressions.scala
@@ -63,6 +63,34 @@ class CommentRenderingRegressions extends FunSpec with Matchers with Inside {
       }
 
     }
+
+    it("github scala-exercises/exercises-stdlib#50") {
+      val comment = commentFactory.parse(s"""
+        /**
+         * {{{
+         * abstract class Soldier(val firstName: String, val lastName: String) {}
+         *
+         * // if you uncomment this line, it will fail compilation
+         * //val soldier = new Soldier
+         * }}}
+         */""")
+
+      inside(Comments.parseAndRender[Mode.Exercise](comment)) {
+        case Right(parsed) ⇒
+          val description = parsed.description
+            .map(_.replaceAll("\\<.*?\\>", ""))
+            .getOrElse("")
+
+          assert(
+            description.trim ==
+              """abstract class Soldier(val firstName: String, val lastName: String) {}
+                |
+                |// if you uncomment this line, it will fail compilation
+                |//val soldier = new Soldier""".stripMargin,
+            "Issue scala-exercises/exercises-stdlib#50: comment rendering problem"
+          )
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This PR fixes the problem with comments being converted to text, first reported in https://github.com/scala-exercises/exercises-stdlib/issues/50

Section in [Parent Classes](https://www.scala-exercises.org/std_lib/parent_classes) before:
<img width="512" alt="parent-classes-before" src="https://user-images.githubusercontent.com/190447/27205973-0ca693ca-522c-11e7-9d73-3d44de2ea2e2.png">

Section in [Parent Classes](https://www.scala-exercises.org/std_lib/parent_classes) after:
<img width="512" alt="parent-classes-after" src="https://user-images.githubusercontent.com/190447/27205979-13a81f68-522c-11e7-9b68-7f9bed9b7b3e.png">

Section in [Type Variance](https://www.scala-exercises.org/std_lib/type_variance) before:
<img width="512" alt="type-variance-before" src="https://user-images.githubusercontent.com/190447/27205986-2219e9aa-522c-11e7-9cc9-96621d59ee00.png">

Section in [Type Variance](https://www.scala-exercises.org/std_lib/type_variance) after:
<img width="512" alt="type-variance-after" src="https://user-images.githubusercontent.com/190447/27205990-27630fae-522c-11e7-985c-2108ff467122.png">

Note: When debugging this problem I realised it might be an issue with scala-ide/scalariform. Since [they're not planning to make any new releases](https://github.com/scala-ide/scalariform/issues/235#issuecomment-288540527) I found this workaround. The previous code was assuming that two spaces are added to each line anyway. I only made sure those are actually spaces.