### PR TITLE
Add jquery and bootstrap.js to library layout (#658)

### DIFF
--- a/server/app/views/templates/library/index.scala.html
+++ b/server/app/views/templates/library/index.scala.html
@@ -129,6 +129,8 @@
     <script src="@routes.Assets.at("lib/highlightjs/languages/scala.min.js")" type="text/javascript"></script>
     <script src="@routes.Assets.at("javascripts/emojify-cdn.js")"></script>
     <script src="@org.scalaexercises.exercises.controllers.routes.ApplicationController.javascriptRoutes" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
     @scalajs.html.scripts(
     "client",
     name => routes.Assets.at(name).toString,


### PR DESCRIPTION
I was checking the bug reported by @AdrianRaFo, @kastoestoramadus and @AntonioMateoGomez  and the problem was in the difference of the files included in footer between home and library layout.

In the library layout we didn't include neither jquery.min.js nor bootstrap.min.js like as home layout.

Adding it, all works fine.

Fixed #658
Fixed #660
Fixed #647