### PR TITLE
Fix exercises consuming 20% CPU due to excessive CSS animation

### DIFF
--- a/server/app/assets/stylesheets/layout/_exercises.scss
+++ b/server/app/assets/stylesheets/layout/_exercises.scss
@@ -60,7 +60,9 @@
         input {
             color: $input-unsolved;
             border-bottom: 1px solid $input-unsolved;
-            -webkit-animation: underliner_unsolved 2s linear infinite;
+            &:focus {
+                -webkit-animation: underliner_unsolved 2s linear infinite;
+            }
         }
         ul.list-sources {
             padding: 0;
@@ -138,7 +140,9 @@
     input {
         color: $input-unsolved;
         border-bottom: 1px solid $input-unsolved;
-        -webkit-animation: underliner_unsolved 2s linear infinite;
+        &:focus {
+            -webkit-animation: underliner_unsolved 2s linear infinite;
+        }
     }
     .bullet-state {
         background: none;
@@ -218,7 +222,9 @@
     input {
         color: $input-errored;
         border-bottom: 1px solid $input-errored;
-        -webkit-animation: underliner_errored 2s linear infinite;
+        &:focus {
+            -webkit-animation: underliner_errored 2s linear infinite;
+        }
     }
     .bullet-state {
         background: url("../images/icon_errored.svg") no-repeat;


### PR DESCRIPTION
I thought I was in browser/extension trouble, but getting feedback from
https://github.com/webcompat/web-bugs/issues/9410 revealed the problem
happens in both Chrome and Firefox.

Looks like all these animations are pretty CPU intensive. Maybe there's
a better solution to this, so consider this PR a glorified issue, and feel free
to rework/change if you find a proper solution rather than my disabling.