### PR TITLE
Better handle syntax sugar for compose examples

### DIFF
--- a/compiler/src/main/scala/org/scalaexercises/exercises/compiler/MethodBodyReader.scala
+++ b/compiler/src/main/scala/org/scalaexercises/exercises/compiler/MethodBodyReader.scala
@@ -62,7 +62,10 @@ object MethodBodyReader {
         )
         (start0, end)
       case _ ⇒
-        (tree.pos.start, tree.pos.end)
+        val source      = tree.pos.source
+        val startOffset = source.lineToOffset(source.offsetToLine(tree.pos.start))
+        val endOffset   = endOfLineOffset(g)(tree, tree.pos.end)
+        (startOffset, endOffset)
     }
   }
 
@@ -70,6 +73,12 @@ object MethodBodyReader {
     if (end > start && isWhitespace(str(end - 1)))
       backstepWhitespace(str, start, end - 1)
     else end
+  }
+
+  @tailrec private def endOfLineOffset[G <: Global](g: G)(tree: g.Tree, endOffset: Int): Int = {
+    if (endOffset < tree.pos.source.length && !tree.pos.source.isEndOfLine(endOffset))
+      endOfLineOffset(g)(tree, endOffset + 1)
+    else endOffset
   }
 
   /** This attempts to find all the individual lines in a method body

--- a/compiler/src/test/scala/org/scalaexercises/exercises/compiler/MethodBodyReaderSpec.scala
+++ b/compiler/src/test/scala/org/scalaexercises/exercises/compiler/MethodBodyReaderSpec.scala
@@ -116,6 +116,21 @@ class MethodBodyReaderSpec extends FunSpec with Matchers with MethodBodyReaderSp
            |println("this is the last line")""".stripMargin
       )
     }
+
+    it("should extract while taking into account syntax sugar") {
+      val code = """
+                   |/** This is an example exercise.
+                   |  * What value returns six?
+                   |  */
+                   |def findSix(value: Int) =
+                   |  (List(2,4,6) compose List(1,2,3)).apply(value)
+                   |
+                 """.stripMargin
+
+      extractSnippet(code) should equal(
+        """(List(2,4,6) compose List(1,2,3)).apply(value)"""
+      )
+    }
   }
 
 }


### PR DESCRIPTION
When a block starts with a value that uses the `(a b c)` syntax sugar for `a.b(c)`, the leading `(` is stripped.

Two examples of this are:

- [Applicative composition](https://www.scala-exercises.org/cats/applicative) in the cats exercises
```scala
Applicative[List] compose Applicative[Option]).pure(1) ...
```
- [Lens composition](https://www.scala-exercises.org/monocle/lens) in the monocle exercises.
```scala
addressLens composeLens streetNumber).get(john) ...
```
I wanted to keep the unit test simple and not worry about imports, so I used composition of the List.apply method for indexing.

I struggled a bit to figure out how to version everything with the plugins in place to be able to test this running scala-exercises locally. Ivy wasn't pulling in my locally published snapshots and rather than futz too much with `sbt-dirty-money` or something, I thought I'd get a PR out for comments first.