### PR TITLE
Validating user progress regarding exercises subject to change

### DIFF
--- a/client/src/main/scala/Effects.scala
+++ b/client/src/main/scala/Effects.scala
@@ -44,7 +44,9 @@ object Effects {
       Client
         .fetchProgress(lib, sect)
         .collect({
-          case Some(state) ⇒ Some(SetState(state))
+          case Some(state) ⇒ {
+            Some(SetState(validateState(state)))
+          }
         })
     })
   }
@@ -61,6 +63,21 @@ object Effects {
               Some(CompilationFail(result.method, result.msg))
           })
       case _ ⇒ noop
+    }
+
+  def validateState(state: List[ClientExercise]): List[ClientExercise] =
+    state.foldLeft(List.empty[ClientExercise]) {
+      (acc: List[ClientExercise], exercise: ClientExercise) =>
+        DomHandler
+          .findExerciseByMethod(exercise.method)
+          .map(DomHandler.inputsInExercise)
+          .fold(acc) { inputs =>
+            if (exercise.arguments.size <= inputs.size) {
+              acc :+ exercise
+            } else {
+              acc :+ exercise.copy(arguments = Seq.empty, state = Unsolved)
+            }
+          }
     }
 
 }

--- a/client/src/main/scala/Effects.scala
+++ b/client/src/main/scala/Effects.scala
@@ -72,7 +72,7 @@ object Effects {
           .findExerciseByMethod(exercise.method)
           .map(DomHandler.inputsInExercise)
           .fold(acc) { inputs =>
-            if (exercise.arguments.size <= inputs.size) {
+            if (exercise.arguments.size == inputs.size) {
               acc :+ exercise
             } else {
               acc :+ exercise.copy(arguments = Seq.empty, state = Unsolved)


### PR DESCRIPTION
Fixes: https://github.com/scala-exercises/exercises-cats/issues/65

This PR tries to fix an issue related to how we handle user progress in the application. In some circumstances an user can have progress stored for an exercise and when coming back to it later this exercise can be changed. If the exercise has less fields than before (i.e.: it's been splitted into two), these extra stored values will still be sent to the external compiler and any evaluation will be rejected for carrying extra parameters for the exercise function.

What this code does is simply verifying the state just after retrieval, to check if we're storing more values than those actually required, and if that's the case invalidating the progress for that exercise in particular (which in my opinion should be desirable, as the exercise has been modified anyway).