### PR TITLE
Updated the link to the Ruby Sass implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Scala Exercises is available at [scala-exercises.org](https://scala-exercises.or
 - Install [Scala](http://scala-lang.org/download/)
 - Install [SBT](http://www.scala-sbt.org/download.html)
 - Install [PostgreSQL 9.4](http://www.postgresql.org/download/)
-- Install the [Sass Ruby gem](http://sass-lang.com/install) and make sure the `sass` program can be run
+- Install the [Sass Ruby gem](https://sass-lang.com/ruby-sass) and make sure the `sass` program can be run
 - Install [jsdom](https://github.com/tmpvar/jsdom) with `npm install jsdom`
 
 #### Installing the app locally


### PR DESCRIPTION
Notes:
- The Ruby Sass implementation has been deprecated in favour of Dart.
- "Ruby Sass will continue to be maintained until 26 March 2019."
- "Dart Sass, the new primary implementation, doesn't always behave 100% the same as Ruby Sass", migration might be non-trivial