### PR TITLE
Ignores Newrelic for Scala-Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+# The dependencies which match the given pattern are NOT updated.
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
+updates.ignore = [ { groupId = "com.newrelic.agent.java", artifactId="newrelic-agent" } ]


### PR DESCRIPTION
Because it needs to update some environment variables in the platform side.