### PR TITLE
Remove Google Plus from index.scala.html template

### DIFF
--- a/server/app/views/templates/home/index.scala.html
+++ b/server/app/views/templates/home/index.scala.html
@@ -191,7 +191,6 @@
 					<ul class="social">
 						<li><a href="https://www.facebook.com/sharer/sharer.php?u=https://scala-exercises.org&t=%22Scala%20Exercises%22%20offers%20hundreds%20of%20exercises%20covering%20the%20main%20concepts%20of%20Scala!"><i class="fa fa-facebook-official"></i></a></li>
 						<li><a href="https://twitter.com/intent/tweet?text=%22Scala%20Exercises%22%20offers%20hundreds%20of%20exercises%20covering%20the%20main%20concepts%20of%20Scala!%20https%3A%2F%2Fscala-exercises.org%2F&source=webclient"><i class="fa fa-twitter"></i></a></li>
-						<li><a href="https://plus.google.com/share?url=https://scala-exercises.org"><i class="fa fa-google-plus"></i></a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
* Remove Google Plus link from the list of shareable services.

This fixes #707 